### PR TITLE
Very simple accept/golden test framework for JIT trees.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # https://travis-ci.org/pytorch/pytorch
 language: python
 python:
-    - 2.7.8
     - 2.7
     - 3.5
     - 3.6

--- a/test/expect/TestJit.test_simple.expect
+++ b/test/expect/TestJit.test_simple.expect
@@ -1,0 +1,11 @@
+graph(%1, %2) {
+  %15 = fusion_group_0(%1, %2), uses = [%15.0.i0];
+  return (%15.0);
+}
+with fusion_group_0 = graph(%5, %8) {
+  %9 = Add!(%5, %8), uses = [%7.i1];
+  %7 = Mul!(%5, %9), uses = [%4.i0];
+  %4 = Tanh!(%7), uses = [%2.i0];
+  %2 = Sigmoid!(%4), uses = [%0.i0];
+  return (%2);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14,7 +14,7 @@ class TestJit(TestCase):
         trace = torch._C._tracer_exit((z,))
 
         # TODO: Do something more automated here
-        print(trace)
+        self.assertExpected(str(trace))
         return
 
         # Re-enable this when the interpreter is back


### PR DESCRIPTION
- To test whether or not a multiline string matches some expected
  value, you can use assertExpected.  This tests that the string
  matches the content stored at a file based on the name of the
  test (and an optional subname parameter you can pass if you
  what to assertExpected multiple times.)

- Suppose you make a change that modifies the output in a big way.
  Instead of manually going through and updating each test, you instead
  run python test/test_jit.py --accept.  This updates all of the expected
  outputs.  You can now review them one-by-one and make sure your
  changes make sense.

We can add more features later (e.g., munging the output to make it
more stable, more sanity checking) but this is just to get us started
testing.  One thing to watch out for is that accept tests on intermediate
representation can be a bit wobbly: it is *extremely* important that
people be able to read the IR.  It may be worth introducing niceties
to the printer in order to ensure this is the case.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>