### PR TITLE
Pointwise Fusion Codegeneration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -304,7 +304,6 @@ main_sources = [
     "torch/csrc/jit/init.cpp",
     "torch/csrc/jit/ir.cpp",
     "torch/csrc/jit/graph_fuser.cpp",
-    "torch/csrc/jit/fusion_compiler.cpp",
     "torch/csrc/jit/test_jit.cpp",
     "torch/csrc/jit/tracer.cpp",
     "torch/csrc/jit/python_ir.cpp",
@@ -377,6 +376,7 @@ if WITH_CUDA:
         "torch/csrc/cuda/utils.cpp",
         "torch/csrc/cuda/expand_utils.cpp",
         "torch/csrc/cuda/serialization.cpp",
+        "torch/csrc/jit/fusion_compiler.cpp",
     ]
     main_sources += split_types("torch/csrc/cuda/Tensor.cpp")
 

--- a/setup.py
+++ b/setup.py
@@ -304,6 +304,8 @@ main_sources = [
     "torch/csrc/jit/init.cpp",
     "torch/csrc/jit/ir.cpp",
     "torch/csrc/jit/graph_fuser.cpp",
+    "torch/csrc/jit/fusion_compiler.cpp",
+    "torch/csrc/jit/test_jit.cpp",
     "torch/csrc/jit/tracer.cpp",
     "torch/csrc/jit/python_ir.cpp",
     "torch/csrc/jit/python_tracer.cpp",
@@ -365,7 +367,7 @@ if WITH_CUDA:
     extra_link_args.append('-Wl,-rpath,' + cuda_lib_path)
     extra_compile_args += ['-DWITH_CUDA']
     extra_compile_args += ['-DCUDA_LIB_PATH=' + cuda_lib_path]
-    main_libraries += ['cudart', 'nvToolsExt']
+    main_libraries += ['cudart', 'nvToolsExt', 'nvrtc', 'cuda']
     main_link_args += [THC_LIB, THCS_LIB, THCUNN_LIB]
     main_sources += [
         "torch/csrc/cuda/Module.cpp",

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -51,6 +51,10 @@ class TestJit(TestCase):
         self.assertEqual(z, z2)
         self.assertEqual(w, w2)
 
+    def test_cpp(self):
+        torch._C._jit_run_cpp_tests()
+
 
 if __name__ == '__main__':
+
     run_tests()

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -217,7 +217,7 @@ private:
   }
   std::string template_text;
 };
-static std::string format(const std::string & fmt, TemplateEnv & env) {
+static inline std::string format(const std::string & fmt, TemplateEnv & env) {
   return CodeTemplate(fmt).format(env);
 }
 

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -1,0 +1,196 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <sstream>
+
+namespace torch { namespace jit {
+
+struct TemplateEnv {
+  TemplateEnv(TemplateEnv * parent = nullptr)
+  : parent(parent) {}
+  using string_list = std::vector<std::string>;
+  // strings
+  void s(const std::string & k, const std::string & v) {
+    strings_[k] = v;
+  }
+  // numbers
+  template<typename T>
+  void d(const std::string & k, const T & v) {
+    strings_[k] = std::to_string(v);
+  }
+  const std::string & s(const std::string & k) const {
+    if(strings_.count(k) == 0) {
+      if(parent) {
+        return parent->s(k);
+      }
+      notFound(k);
+    }
+    return strings_.at(k);
+  }
+  // lists of strings
+  void v(const std::string & k, const string_list & v) {
+    lists_[k] = v;
+  }
+  const string_list & v(const std::string & k) const {
+    if(lists_.count(k) == 0) {
+      if(parent) {
+        return parent->v(k);
+      }
+      notFound(k);
+    }
+    return lists_.at(k);
+  }
+  bool keyIsString(const std::string & k) const {
+    if(strings_.count(k) > 0)
+      return true;
+    if(lists_.count(k) > 0)
+      return false;
+    if(parent)
+      return parent->keyIsString(k);
+    notFound(k);
+  }
+private:
+  [[ noreturn ]]
+  void notFound(const std::string & k) const {
+    std::stringstream ss;
+    ss << "key not found: " << k;
+    throw std::logic_error(ss.str());
+  }
+  std::unordered_map<std::string,std::string> strings_;
+  std::unordered_map<std::string,string_list> lists_;
+  TemplateEnv * parent;
+};
+
+/*
+# Match $identifier or ${identifier} and replace with value in env.
+# If this identifier is at the beginning of whitespace on a line
+# and its value is a list then it is treated as
+# block subsitution by indenting all lines of all elements.
+# If the identifier is on a line starting with non-whitespace and a list
+# then it is comma separated. ${,foo} will insert a comma before the list
+# if this list is not empty and ${foo,} will insert one after.
+*/
+struct CodeTemplate {
+  /* implicit */ CodeTemplate(const std::string & t)
+  : template_text(t) {}
+
+  std::string format(const TemplateEnv & env) {
+    std::stringstream out;
+    size_t pos = 0;
+    size_t indent = 0;
+    bool all_whitespace = true;
+    while(pos < template_text.size()) {
+      char c = template_text[pos];
+      if(c == '$') {
+        std::stringstream kss;
+        bool comma_before;
+        bool comma_after;
+        size_t new_pos = parseKey(pos,kss,comma_before,comma_after);
+        std::string k = kss.str();
+        bool is_string = env.keyIsString(k);
+        if(all_whitespace) {
+          if(is_string)
+            emitStringWithIndents(out, indent, env.s(k));
+          else
+            emitLinesIndented(out, indent, env.v(k));
+        } else {
+          if(is_string)
+            out << env.s(k);
+          else
+            emitCommaSeparatedList(out, env.v(k), comma_before, comma_after);
+        }
+        all_whitespace = false;
+        pos = new_pos;
+      } else {
+        out << c;
+        if(!isspace(c))
+          all_whitespace = false;
+        indent++;
+        if(c == '\n') {
+          indent = 0;
+          all_whitespace = true;
+        }
+        pos++;
+      }
+    }
+    return out.str();
+  }
+private:
+  using string_list = std::vector<std::string>;
+  char charAt(size_t p) {
+    if (p >= template_text.size())
+      throw std::logic_error("EOS found in key");
+    return template_text[p];
+  }
+  size_t parseKey(size_t pos, std::ostream & k, bool & comma_before, bool & comma_after) {
+    comma_before = false;
+    comma_after = false;
+    pos++;
+    if(charAt(pos) == '{') {
+      pos++;
+      if(charAt(pos) == ',') {
+        comma_before = true;
+        pos++;
+      }
+      pos = parseIdent(pos, k);
+      if(charAt(pos) == ',') {
+        comma_after = true;
+        pos++;
+      }
+      if(charAt(pos) != '}')
+        throw std::logic_error("missing terminating '}'");
+      pos++;
+      return pos;
+    } else {
+      return parseIdent(pos, k);
+    }
+  }
+  size_t parseIdent(size_t pos, std::ostream & k) {
+    while(pos < template_text.size() &&
+      (isalnum(template_text[pos]) || template_text[pos] == '_')) {
+      k << template_text[pos];
+      pos++;
+    }
+    return pos;
+  }
+  void emitCommaSeparatedList(std::ostream & out, const string_list & strings, bool comma_before, bool comma_after) {
+    if(comma_before && strings.size() > 0)
+      out << ", ";
+    for(size_t i = 0; i < strings.size(); ++i) {
+      if(i > 0)
+        out << ", ";
+      out << strings[i];
+    }
+    if(comma_after && strings.size() > 0)
+      out << ", ";
+  }
+  void emitIndent(std::ostream & out, size_t indent) {
+    for(size_t i = 0; i < indent; ++i) {
+      out << " ";
+    }
+  }
+  void emitStringWithIndents(std::ostream & out, size_t indent, const std::string & str) {
+    for(auto c : str) {
+      out << c;
+      if(c == '\n') {
+        emitIndent(out, indent);
+      }
+    }
+  }
+  void emitLinesIndented(std::stringstream & out, size_t indent, const string_list & strings) {
+    for(size_t i = 0; i < strings.size(); ++i) {
+      if(i > 0)
+        emitIndent(out, indent);
+      emitStringWithIndents(out,indent,strings[i]);
+      if(i+1 != strings.size())
+        out << "\n";
+    }
+  }
+  std::string template_text;
+};
+static std::string format(const std::string & fmt, TemplateEnv & env) {
+  return CodeTemplate(fmt).format(env);
+}
+
+}}

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -83,10 +83,10 @@ private:
 };
 
 /*
-# Match $identifier or ${identifier} and replace with value in env.
+# Match $identifier or ${identifier} and replace with the value in env.
 # If this identifier is at the beginning of whitespace on a line
 # and its value is a list then it is treated as
-# block subsitution by indenting all lines of all elements.
+# block substitution by indenting all lines of all elements.
 # If the identifier is on a line starting with non-whitespace and a list
 # then it is comma separated. ${,foo} will insert a comma before the list
 # if this list is not empty and ${foo,} will insert one after.

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -6,6 +6,13 @@
 
 namespace torch { namespace jit {
 
+// A template environment is a mapping from template variable names, e.g.,
+// identifier (corresponding to $identifier) to their expansions.
+//
+// This template environment supports storing strings, numbers and lists
+// of strings, and can be chained together (so that lookup proceeds in
+// in the top level environment, and then recurses into a parent
+// environment if the key is not found.)
 struct TemplateEnv {
   TemplateEnv(TemplateEnv * parent = nullptr)
   : parent(parent) {}

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -14,18 +14,25 @@ namespace torch { namespace jit {
 // in the top level environment, and then recurses into a parent
 // environment if the key is not found.)
 struct TemplateEnv {
+  
   TemplateEnv(TemplateEnv * parent = nullptr)
   : parent(parent) {}
+  
   using string_list = std::vector<std::string>;
-  // strings
+  
+  // Add a string 'v' to the map at key 'k'.
   void s(const std::string & k, const std::string & v) {
     strings_[k] = v;
   }
-  // numbers
+  
+  // Add a number 'v' to the map at key 'k'
   template<typename T>
   void d(const std::string & k, const T & v) {
     strings_[k] = std::to_string(v);
   }
+  
+  // Retrieve the string representation of the value stored at 'k' from the map.
+  // Raises an exception if the key is not found.
   const std::string & s(const std::string & k) const {
     if(strings_.count(k) == 0) {
       if(parent) {
@@ -35,10 +42,14 @@ struct TemplateEnv {
     }
     return strings_.at(k);
   }
-  // lists of strings
+  
+  // Store a list of strings 'v' in the map at 'k'.
   void v(const std::string & k, const string_list & v) {
     lists_[k] = v;
   }
+  
+  // Retrieve a list of strings stored at 'k' from the map.
+  // Raises an exception if the key is not found.
   const string_list & v(const std::string & k) const {
     if(lists_.count(k) == 0) {
       if(parent) {
@@ -48,6 +59,8 @@ struct TemplateEnv {
     }
     return lists_.at(k);
   }
+  
+  // Test if a string 'k' is a string (as opposed to a list.)
   bool keyIsString(const std::string & k) const {
     if(strings_.count(k) > 0)
       return true;

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -185,6 +185,10 @@ private:
     if(comma_after && strings.size() > 0)
       out << ", ";
   }
+  // These indentation functions follow the convention that they never emit
+  // leading or trailing newlines when the input string does not have leading
+  // or trailing newlines. It's the responsibility of the calling function
+  // to indent correctly in the context.
   void emitIndent(std::ostream & out, size_t indent) {
     for(size_t i = 0; i < indent; ++i) {
       out << " ";

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -14,23 +14,26 @@ namespace torch { namespace jit {
 // in the top level environment, and then recurses into a parent
 // environment if the key is not found.)
 struct TemplateEnv {
-  
-  TemplateEnv(TemplateEnv * parent = nullptr)
-  : parent(parent) {}
-  
+  TemplateEnv()
+  : parent(nullptr) {}
+  TemplateEnv(TemplateEnv & parent)
+  : parent(&parent) {}
+
   using string_list = std::vector<std::string>;
-  
+
   // Add a string 'v' to the map at key 'k'.
   void s(const std::string & k, const std::string & v) {
     strings_[k] = v;
+    lists_.erase(k);
   }
-  
+
   // Add a number 'v' to the map at key 'k'
   template<typename T>
   void d(const std::string & k, const T & v) {
     strings_[k] = std::to_string(v);
+    lists_.erase(k);
   }
-  
+
   // Retrieve the string representation of the value stored at 'k' from the map.
   // Raises an exception if the key is not found.
   const std::string & s(const std::string & k) const {
@@ -42,12 +45,13 @@ struct TemplateEnv {
     }
     return strings_.at(k);
   }
-  
+
   // Store a list of strings 'v' in the map at 'k'.
   void v(const std::string & k, const string_list & v) {
     lists_[k] = v;
+    strings_.erase(k);
   }
-  
+
   // Retrieve a list of strings stored at 'k' from the map.
   // Raises an exception if the key is not found.
   const string_list & v(const std::string & k) const {
@@ -59,7 +63,7 @@ struct TemplateEnv {
     }
     return lists_.at(k);
   }
-  
+
   // Test if a string 'k' is a string (as opposed to a list.)
   bool keyIsString(const std::string & k) const {
     if(strings_.count(k) > 0)

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -1,0 +1,394 @@
+#include "torch/csrc/jit/fusion_compiler.h"
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/DisallowCopy.h"
+#include "torch/csrc/jit/code_template.h"
+#include "ATen/ATen.h"
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <string>
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+#include <sstream>
+#include <assert.h>
+#include <iostream>
+
+namespace torch { namespace jit {
+
+void findContiguous(
+  at::IntList sizes,
+  at::IntList strides,
+  std::vector<bool> & cont) {
+  assert(sizes.size() == strides.size());
+  cont.resize(sizes.size());
+  for(size_t i = 0; i < sizes.size(); ++i) {
+    int64_t expected_stride = (i + 1 < sizes.size()) ? sizes[i+1]*strides[i+1] : 1;
+    cont[i] = strides[i] == expected_stride;
+  }
+}
+
+// compress dimensions when the tensor is marked as cont
+// anytime we do a compression, we assert that it is valid for this particular tensor.
+static void compressContiguous(
+  at::IntList sizes,
+  at::IntList strides,
+  const std::vector<bool> & cont,
+  uint32_t * c_sizes,
+  uint32_t * c_strides) {
+  size_t c = 0;
+  size_t cur = 0;
+  size_t ndim = sizes.size();
+  while(cur < ndim) {
+    size_t total_size = sizes[cur];
+    cur++;
+    while(cont[cur-1] && cur < ndim) {
+      JIT_ASSERT(strides[cur-1] == sizes[cur]*strides[cur]);
+      total_size *= sizes[cur];
+      cur++;
+    }
+   // cur starts pointing at the beginning of run to compress
+   // cur ends one _after_ the terminating false or end of list.
+   // total_size is the size of all dimensions [begin,end)
+   // examples:
+   // f = not cont.
+   // t = cont.
+   // x = don't care, including past end of list
+   // s = start of cur
+   // e = end of cur
+
+
+   // f x x x
+   // s e
+
+   //  t f x x
+   //  s   e
+
+   //  t t f x
+   //  s     e
+
+    c_sizes[c] = total_size;
+    c_strides[c] = strides[cur-1];
+    c++;
+  }
+  JIT_ASSERT(!cont.back() || strides.back() == 1);
+}
+
+static auto compilation_unit_template = CodeTemplate(R"(
+typedef ${IndexType} IndexType;
+template<typename T, size_t N>
+struct TensorInfo {
+  T * data;
+  IndexType sizes[N];
+  IndexType strides[N];
+};
+
+extern "C" __global__
+void ${kernelName}(IndexType totalElements, ${formals}) {
+  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+        linearIndex < totalElements;
+        linearIndex += gridDim.x * blockDim.x) {
+      // Convert `linearIndex` into an offset of tensor:
+      ${tensorOffsets}
+      // calculate the results
+      ${kernelBody}
+    }
+}
+)");
+
+// curDimIndex = linearId % sizes[i]; // % sizes[i] is not needed for d == 0, because we already guard for numel outside the index calculation
+// offset += curDimIndex*strides[i]; // *strides[i] is optional if list_is_cont becaause strides.back() == 1
+// linearId /= sizes[i];
+static auto dim_calc = CodeTemplate(R"(
+//printf("tensor ${tensor} sizes[${d}] = %d, strides[${d}] = %d\n", ${tensor}.sizes[${d}],${tensor}.strides[${d}]);
+size_t ${tensor}_dimIndex${d} = ${tensor}_linearIndex ${mod_sizes};
+${tensor}_offset += ${tensor}_dimIndex${d} ${times_stride};
+)");
+
+static void emitIndexingFor(std::ostream & out, const std::string & tensor, int ndim, bool last_is_cont) {
+  TemplateEnv env;
+  env.s("tensor",tensor);
+  out << format("IndexType ${tensor}_offset = 0;\n",env);
+  out << format("IndexType ${tensor}_linearIndex = linearIndex;\n",env);
+  for(int d = ndim - 1; d >= 0; --d) {
+    env.d("d",d);
+    env.s("mod_sizes", d > 0 ? format("% ${tensor}.sizes[${d}]",env) : "");
+    env.s("times_stride",(d < ndim - 1 || !last_is_cont) ?
+      format("* ${tensor}.strides[${d}]",env) : "");
+    out << dim_calc.format(env);
+    if(d > 0) {
+      out << format("${tensor}_linearIndex /= ${tensor}.sizes[${d}];\n",env);
+    }
+  }
+}
+
+static std::ostream& operator<<(std::ostream & out, const TensorDesc & d) {
+  out << d.scalar_type << "[";
+  for(auto b : d.contiguity)
+    out << b << ";";
+  out << "]";
+  return out;
+}
+
+static std::string nodeName(Node * n) {
+  return "n"+std::to_string(n->unique());
+}
+
+static std::unordered_map<std::string,std::string> simple_map_ops = {
+  {"Sigmoid","1.f / (1.f + expf(-${0}))"},
+  {"Tanh","tanh(${0})"},
+  {"Mul","${0} * ${1}"},
+  {"Add","${0} + ${1}"},
+};
+
+const char * toCString(at::ScalarType type) {
+  switch(type) {
+    #define DEFINE_CASE(ctype,name,_) \
+      case at::ScalarType::name: return #ctype;
+    AT_FORALL_SCALAR_TYPES(DEFINE_CASE)
+    #undef DEFINE_CASE
+    default:
+      throw new std::runtime_error("unknown scalar type");
+  }
+}
+
+void emitCompilationUnit(std::ostream & out,
+  const std::string & name,
+  AnnotatedGraph & agraph) {
+  Graph& subgraph = *agraph.graph;
+  TemplateEnv env;
+  env.s("kernelName",name);
+  env.s("IndexType","unsigned int"); //avoiding slow header includes to get uint32_t
+
+  std::stringstream body;
+  std::stringstream tensorOffsets;
+  std::vector<std::string> formals;
+  auto emitFormal = [&](Node * n, const TensorDesc & desc) {
+    std::string tensor = "t" + std::to_string(formals.size()); //can't be unique() because Param may be an output
+    size_t nDim = desc.nDim();
+    emitIndexingFor(tensorOffsets, tensor, nDim,  desc.lastIsContiguous());
+    env.s("tensor",tensor);
+    env.d("nDim",nDim);
+    env.s("scalar_type",toCString(desc.scalar_type));
+    formals.push_back(format("TensorInfo<${scalar_type},${nDim}> ${tensor}",env));
+  };
+  {
+    size_t i = 0;
+    for(auto p : subgraph.inputs())
+      emitFormal(p,agraph.input_desc[i++]);
+  }
+  {
+    size_t i = 0;
+    for(auto o : subgraph.outputs())
+      emitFormal(o,agraph.output_desc[i++]);
+  }
+  size_t formal_count = 0;
+  for(auto p : subgraph.inputs()) {
+    env.s("node",nodeName(p));
+    env.d("formal",formal_count++);
+    env.s("access",format("t${formal}.data[t${formal}_offset]",env));
+    // TODO: auto doesn't work so we need to do shape/type inference
+    body << format("auto ${node} = ${access};\n",env);
+  }
+  for(auto n_ : subgraph.nodes()) {
+    if(n_->kind() == NodeKind::Return)
+      continue; //TODO: remove when return is not in list
+    auto n = n_->cast<SimpleMap>();
+    JIT_ASSERT(n);
+    size_t i = 0;
+    for(auto in : n->inputs()) {
+      env.s(std::to_string(i++),nodeName(in));
+    }
+    env.s("node",nodeName(n));
+    env.s("rhs",format(simple_map_ops.at(n->op),env));
+    body << format("auto ${node} = ${rhs};\n",env);
+  }
+  for(auto o : subgraph.outputs()) {
+    env.d("formal",formal_count++);
+    env.s("access",format("t${formal}.data[t${formal}_offset]",env));
+    env.s("node",nodeName(o));
+    body << format("${access} = ${node};\n",env);
+  }
+  env.s("tensorOffsets",tensorOffsets.str());
+  env.s("kernelBody",body.str());
+  env.v("formals",formals);
+  out << compilation_unit_template.format(env);
+}
+
+static void nvrtcCheck(nvrtcResult result,const char * file, int line) {
+  if(result != NVRTC_SUCCESS) {
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << nvrtcGetErrorString(result);
+    throw std::runtime_error(ss.str());
+  }
+}
+#define JIT_NVRTC_CHECK(result) \
+  nvrtcCheck(result,__FILE__,__LINE__);
+
+#define JIT_CU_CHECK(result) \
+  cuCheck(result,__FILE__,__LINE__);
+static void cuCheck(CUresult result, const char * file, int line) {
+  if(result != CUDA_SUCCESS) {
+    const char * str;
+    cuGetErrorString(result, &str);
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << str;
+    throw std::runtime_error(ss.str());
+  }
+}
+#define JIT_CU_CHECK(result) \
+  cuCheck(result,__FILE__,__LINE__);
+
+static void cudaCheck(cudaError_t result, const char * file, int line) {
+  if(result != cudaSuccess) {
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << cudaGetErrorString(result);
+    throw std::runtime_error(ss.str());
+  }
+}
+#define JIT_CUDA_CHECK(result) \
+    cudaCheck(result,__FILE__,__LINE__);
+
+static int cielDiv(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+//host-side view of TensorInfo
+//note dims[0], because we need to dynamically allocate the dims
+struct TensorInfo {
+  void * data;
+  uint32_t dims[0];
+  uint32_t* sizes(size_t nDim) {
+    return &dims[0];
+  }
+  uint32_t* strides(size_t nDim) {
+    return &dims[nDim];
+  }
+};
+
+CompiledFusionFunction::CompiledFusionFunction(const std::string & name, AnnotatedGraph & agraph)
+: name(name), input_desc(agraph.input_desc), output_desc(agraph.output_desc) {
+  std::stringstream cu;
+  emitCompilationUnit(cu, name, agraph);
+  compliation_unit = cu.str();
+  nvrtcProgram program;
+  JIT_NVRTC_CHECK(nvrtcCreateProgram(&program,compliation_unit.c_str(), NULL, 0, nullptr, nullptr));
+  cudaDeviceProp deviceProp;
+  JIT_CUDA_CHECK(cudaGetDevice(&device));
+  JIT_CUDA_CHECK(cudaGetDeviceProperties(&deviceProp, device));
+  std::string compute = "--gpu-architecture=compute_" + std::to_string(deviceProp.major) + std::to_string(deviceProp.minor);
+  std::vector<const char *> args = {"--std=c++11", compute.c_str()};
+  nvrtcResult result = nvrtcCompileProgram(program, args.size(), args.data());
+  if(result == NVRTC_ERROR_COMPILATION) {
+    size_t logsize;
+    nvrtcGetProgramLogSize(program, &logsize);
+    std::vector<char> log(logsize);
+    nvrtcGetProgramLog(program, log.data());
+    cu << log.data();
+    throw std::runtime_error(cu.str());
+  }
+  JIT_NVRTC_CHECK(result);
+  size_t ptx_size;
+  JIT_NVRTC_CHECK(nvrtcGetPTXSize(program, &ptx_size));
+  ptx.resize(ptx_size);
+  JIT_NVRTC_CHECK(nvrtcGetPTX(program, ptx.data()));
+  JIT_NVRTC_CHECK(nvrtcDestroyProgram(&program));
+
+  JIT_CU_CHECK(cuModuleLoadData(&module, ptx.data()));
+  JIT_CU_CHECK(cuModuleGetFunction(&function, module, name.c_str()));
+
+  JIT_CU_CHECK(cuOccupancyMaxActiveBlocksPerMultiprocessor(
+    &maxBlocks, function, 128, 0));
+  JIT_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  maxBlocks *= prop.multiProcessorCount;
+}
+CompiledFusionFunction::~CompiledFusionFunction() {
+  JIT_CU_CHECK(cuModuleUnload(module));
+}
+
+void CompiledFusionFunction::launch(at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs) {
+  JIT_ASSERT(inputs.size() == input_desc.size());
+  JIT_ASSERT(outputs.size() == output_desc.size());
+  size_t uncompressedDim = input_desc.at(0).contiguity.size();
+  uint32_t numel = inputs[0].numel();
+  size_t maxPossibleTensorInfoSize = sizeof(TensorInfo) + 2*sizeof(uint32_t)*uncompressedDim;
+  size_t maxPossibleBufferSize = maxPossibleTensorInfoSize * (inputs.size() + outputs.size());
+  std::vector<char> buffer(maxPossibleBufferSize);
+  char * buffer_next = buffer.data();
+  std::vector<void*> arguments;
+  arguments.reserve(1 + inputs.size() + outputs.size());
+  auto addTensorInfo = [&](TensorDesc & desc, const at::Tensor & t) {
+    size_t nDim = desc.nDim(); //the compressed dim
+    auto ti = reinterpret_cast<TensorInfo*>(buffer_next);
+    ti->data = t.data_ptr();
+    compressContiguous(t.sizes(), t.strides(), desc.contiguity, ti->sizes(nDim), ti->strides(nDim));
+    buffer_next += maxPossibleTensorInfoSize;
+    arguments.push_back(ti);
+  };
+  arguments.push_back(&numel);
+  {
+    size_t i = 0;
+    for(auto & desc : input_desc) {
+      addTensorInfo(desc,inputs[i++]);
+    }
+  }
+  {
+    size_t i = 0;
+    for(auto & desc : output_desc) {
+      addTensorInfo(desc,outputs[i++]);
+    }
+  }
+  launch(numel, arguments.data());
+}
+
+void CompiledFusionFunction::launch(uint32_t numel, void ** arguments) {
+int numBlocks = std::min(maxBlocks,cielDiv(numel,blockSize));
+  //std::cout << "maxBlocks = " << maxBlocks << " needed blocks: " << cielDiv(numel,blockSize)
+  //          << " numblocks =  " << numBlocks;
+
+  JIT_CU_CHECK(cuLaunchKernel(
+    function,
+    numBlocks, 1, 1,
+    blockSize, 1, 1,
+    0, nullptr,
+    arguments,
+    nullptr));
+}
+
+
+
+
+FusionCompiler::FusionCompiler() {}
+std::shared_ptr<CompiledFusionFunction> FusionCompiler::getOrCompile(AnnotatedGraph & agraph) {
+  std::stringstream key;
+  key << *agraph.graph << "\n";
+  int device;
+  JIT_CUDA_CHECK(cudaGetDevice(&device));
+  key << "Device " << device << "\n";
+  for(auto & i : agraph.input_desc)
+    key << i << "\n";
+  for(auto & i : agraph.output_desc)
+    key << i << "\n";
+  std::string key_ = key.str();
+  auto it = cache.find(key_);
+  if(it == cache.end()) {
+    std::string name = "kernel_" + std::to_string(cache.size());
+    auto func = std::make_shared<CompiledFusionFunction>(name,agraph);
+    it = cache.emplace(key_,std::move(func)).first;
+  }
+  return it->second;
+}
+
+void FusionCompiler::debugLaunchGraph(Graph & graph, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs) {
+  AnnotatedGraph agraph { &graph };
+  for(auto & i : inputs) {
+    agraph.input_desc.emplace_back(i);
+  }
+  for(auto & i : outputs) {
+    agraph.output_desc.emplace_back(i);
+  }
+  auto func = getOrCompile(agraph);
+  func->launch(inputs, outputs);
+}
+
+}}

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -11,10 +11,9 @@
 
 namespace torch { namespace jit {
 
-void findContiguous(
+std::vector<bool> findContiguous(
   at::IntList sizes,
-  at::IntList strides,
-  std::vector<bool> & cont);
+  at::IntList strides);
 
 // type information needed by the compiler for input/outputs
 // contiguity[i] is true if the dim i is contiguous with dim i + 1.
@@ -27,8 +26,8 @@ struct TensorDesc {
     calcDim();
   }
   TensorDesc(const at::Tensor & t)
-  : scalar_type(t.type().scalarType()) {
-    findContiguous(t.sizes(), t.strides(), contiguity);
+  : scalar_type(t.type().scalarType()),
+    contiguity(findContiguous(t.sizes(), t.strides())) {
     calcDim();
   }
   // number of dimensions after contiguity compression

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -1,0 +1,100 @@
+#pragma once
+#include <torch/csrc/jit/ir.h>
+#include "torch/csrc/jit/DisallowCopy.h"
+#include "ATen/ATen.h"
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <string>
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
+namespace torch { namespace jit {
+
+void findContiguous(
+  at::IntList sizes,
+  at::IntList strides,
+  std::vector<bool> & cont);
+
+// type information needed by the compiler for input/outputs
+// contiguity[i] is true if the dim i is contiguous with dim i + 1.
+// contiguity.back() == true means strides.back() == 1.
+struct TensorDesc {
+  at::ScalarType scalar_type;
+  std::vector<bool> contiguity;
+  TensorDesc(at::ScalarType scalar_type, const std::vector<bool> & contiguity)
+  : scalar_type(scalar_type), contiguity(contiguity) {
+    calcDim();
+  }
+  TensorDesc(const at::Tensor & t)
+  : scalar_type(t.type().scalarType()) {
+    findContiguous(t.sizes(), t.strides(), contiguity);
+    calcDim();
+  }
+  // number of dimensions after contiguity compression
+  size_t nDim() const {
+    return nDim_;
+  }
+  // do we have inner stride == 1?
+  bool lastIsContiguous() const {
+    return contiguity.size() == 0 || contiguity.back();
+  }
+private:
+  size_t nDim_;
+  void calcDim() {
+    nDim_ = std::count(contiguity.begin(), contiguity.end(), false)
+    + (lastIsContiguous() ? 1 : 0);
+  }
+};
+
+// short-term storage only, so it borrows Graph.
+// this type is probably temporary.
+// it will be replaced when the needed TensorDesc information is encoded
+// directly in the information in the IR (e.g. in the Type object)
+struct AnnotatedGraph {
+  Graph* graph;
+  std::vector<TensorDesc> input_desc;
+  std::vector<TensorDesc> output_desc;
+};
+
+struct CompiledFusionFunction {
+  TH_DISALLOW_COPY_AND_ASSIGN(CompiledFusionFunction);
+
+  CompiledFusionFunction(const std::string & name, AnnotatedGraph & agraph);
+  ~CompiledFusionFunction();
+  void launch(at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs);
+private:
+  void launch(uint32_t numel, void ** arguments);
+  std::string name;
+  //we keep these around for debugging
+  std::string compliation_unit;
+  std::vector<char> ptx;
+  CUmodule module;
+  CUfunction function;
+
+  // we record prop/device so if they are availiable for launch heuristics
+  // querying at launch is too slow for device properties.
+  int device;
+  cudaDeviceProp prop;
+  int blockSize = 128;
+  int maxBlocks;
+
+  std::vector<TensorDesc> input_desc;
+  std::vector<TensorDesc> output_desc;
+};
+
+// caching compiler
+struct FusionCompiler {
+  TH_DISALLOW_COPY_AND_ASSIGN(FusionCompiler);
+  FusionCompiler();
+  std::shared_ptr<CompiledFusionFunction> getOrCompile(AnnotatedGraph & agraph);
+  // debugging function that lets you do everything from compilation to execution
+  // in one step.
+  // this should not be used in the hot path of execution because it has to serialize
+  // the graph each time
+  void debugLaunchGraph(Graph & graph, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs);
+private:
+  std::unordered_map<std::string, std::shared_ptr<CompiledFusionFunction> > cache;
+};
+
+}}

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -21,6 +21,12 @@ PyObject * THPJIT_initExtension(PyObject *_unused)
   Py_RETURN_TRUE;
 }
 
+// stub to run all C++ only tests for the JIT
+// the stuff in test_jit.cpp is kept separate from the rest of PyTorch
+// so we can build and iterate on it faster.
+// from test_jit.cpp
+namespace torch  { namespace jit { extern void runJITCPPTests(); } };
+
 namespace {
 
 using namespace torch::jit;
@@ -37,12 +43,20 @@ PyObject * wrap_optimizer(PyObject *_unused, PyObject *py_graph) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject * run_cpp_tests(PyObject *_unused, PyObject *_unused2) {
+    HANDLE_TH_ERRORS
+    runJITCPPTests();
+    Py_RETURN_NONE;
+    END_HANDLE_TH_ERRORS
+}
+
 struct PyMethodDef _THPJIT_methods[] = {
   {"_jit_init",       (PyCFunction)THPJIT_initExtension,      METH_NOARGS,  NULL},
   {"_tracer_enter",   (PyCFunction)THPTracer_enter,           METH_VARARGS, NULL},
   {"_tracer_exit",    (PyCFunction)THPTracer_exit,            METH_VARARGS, NULL},
   {"_jit_createAutogradClosure", (PyCFunction)THPTracer_createAutogradClosure, METH_O, NULL},
   {"_jit_optim_fuse", (PyCFunction)wrap_optimizer<FuseGraph>, METH_O,       NULL},
+  {"_jit_run_cpp_tests",(PyCFunction)run_cpp_tests,           METH_NOARGS,  NULL},
   {NULL}
 };
 

--- a/torch/csrc/jit/resource_guard.h
+++ b/torch/csrc/jit/resource_guard.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <functional>
+
+namespace torch { namespace jit {
+
+class ResourceGuard {
+  std::function<void()> _destructor;
+  bool _released;
+
+public:
+  ResourceGuard(std::function<void()> destructor)
+    : _destructor(std::move(destructor))
+    , _released(false) {}
+
+  ~ResourceGuard() {
+    if (!_released) _destructor();
+  }
+
+  void release() {
+    _released = true;
+  }
+};
+
+}}

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -1,0 +1,162 @@
+#include <iostream>
+#include "torch/csrc/jit/fusion_compiler.h"
+#include "torch/csrc/jit/code_template.h"
+
+namespace torch { namespace jit {
+
+template<typename T>
+static std::ostream & operator<<(std::ostream & out, const std::vector<T> & list) {
+  size_t i = 0;
+  out << "{";
+  for(auto && e : list) {
+    if(i++ > 0)
+      out << ", ";
+    out << e;
+  }
+  out << "}";
+  return out;
+}
+using AR = ArrayRef<Node*>;
+
+static auto ct = CodeTemplate(R"(
+int foo($args) {
+
+    $bar
+        $bar
+    $a+$b
+}
+int commatest(int a${,stuff})
+int notest(int a${,empty,})
+)");
+static auto ct_expect = R"(
+int foo(hi, 8) {
+
+    what
+    on many
+    lines...
+    7
+        what
+        on many
+        lines...
+        7
+    3+4
+}
+int commatest(int a, things..., others)
+int notest(int a)
+)";
+
+static void codeTemplateTest() {
+  {
+    TemplateEnv e;
+    e.s("hi","foo");
+    e.v("what",{"is","this"});
+    TemplateEnv c(&e);
+    c.s("hi","foo2");
+    JIT_ASSERT(e.s("hi") == "foo");
+    JIT_ASSERT(c.s("hi") == "foo2");
+    JIT_ASSERT(e.v("what")[0] == "is");
+  }
+
+  {
+    TemplateEnv e;
+    e.v("args",{"hi","8"});
+    e.v("bar",{"what\non many\nlines...","7"});
+    e.s("a","3");
+    e.s("b","4");
+    e.v("stuff",{"things...","others"});
+    e.v("empty",{});
+    auto s = ct.format(e);
+    //std::cout << "'" << s << "'\n";
+    //std::cout << "'" << ct_expect << "'\n";
+    JIT_ASSERT(s == ct_expect);
+  }
+}
+
+static void fusionTests() {
+  FusionCompiler comp;
+  cudaFree(0);
+
+  auto testSimple = [&] {
+    Graph graph;
+    Node * i0 = graph.addInput();
+    Node * i1 = graph.addInput();
+    auto o0 = graph.appendNewNode<SimpleMap>("Mul",AR({i0, i1}));
+    graph.registerOutput(o0);
+    auto a = at::CUDA(at::kFloat).rand({3,4});
+    auto b = at::CUDA(at::kFloat).rand({4,3}).transpose(0,1);
+    auto o = at::CUDA(at::kFloat).zeros({3,4});
+    comp.debugLaunchGraph(graph, {a,b}, {o});
+    auto o2 = a*b;
+    float max_diff = (o2 - o).abs().max().toDouble();
+    //std::cout << "max diff: " << max_diff << "\n";
+    JIT_ASSERT(max_diff == 0);
+  };
+  testSimple();
+
+  auto testOne = [&](int ti, int tj, int toi, int toj) {
+
+    Graph graph;
+
+    Node * i0 = graph.addInput();
+    Node * i1 = graph.addInput();
+    Node * i2 = graph.addInput();
+    Node * i3 = graph.addInput();
+    Node * i4 = graph.addInput();
+
+    auto p22 = graph.appendNewNode<SimpleMap>("Sigmoid",AR({i4}));
+    auto p20 = graph.appendNewNode<SimpleMap>("Sigmoid",AR({i3}));
+    auto p18 = graph.appendNewNode<SimpleMap>("Tanh",AR({i2}));
+    auto p16 = graph.appendNewNode<SimpleMap>("Sigmoid",AR({i1}));
+    auto p14 = graph.appendNewNode<SimpleMap>("Mul",AR({p20, i0}));
+    auto p11 = graph.appendNewNode<SimpleMap>("Mul",AR({p22, p18}));
+    auto o1 = graph.appendNewNode<SimpleMap>("Add",AR({p14, p11}));
+    auto p5 = graph.appendNewNode<SimpleMap>("Tanh",AR({o1}));
+    auto o0 = graph.appendNewNode<SimpleMap>("Mul",AR({p16, p5}));
+
+    graph.registerOutput(o0);
+    graph.registerOutput(o1);
+
+    std::vector<at::Tensor> inputs;
+    std::vector<at::Tensor> outputs;
+    for(size_t i = 0; i < graph.inputs().size(); i++) {
+      inputs.push_back(at::CUDA(at::kFloat).rand({128,128,32}).transpose(ti, tj));
+    }
+    for(size_t i = 0; i < graph.outputs().size(); i++) {
+      outputs.push_back(at::CUDA(at::kFloat).zeros({128,128,32}).transpose(toi,toj));
+    }
+
+    auto t22 = inputs[4].sigmoid();
+    auto t20 = inputs[3].sigmoid();
+    auto t18 = inputs[2].tanh();
+    auto t16 = inputs[1].sigmoid();
+    auto t14 = t20*inputs[0];
+    auto t11 = t22*t18;
+    auto out1 = t14+t11;
+    auto t5 = out1.tanh();
+    auto out0 = t16*t5;
+
+
+    //auto out0 = inputs[0]*inputs[1];
+    comp.debugLaunchGraph(graph, inputs, outputs);
+    float max_diff = (outputs.front() - out0).abs().max().toDouble();
+    //std::cout << "max diff: " << max_diff << "\n";
+    JIT_ASSERT(max_diff < 1e-6);
+
+  };
+  testOne(0,0,0,0);
+  testOne(0,1,0,0);
+  testOne(1,2,0,0);
+  testOne(0,2,0,0);
+
+  testOne(0,0,0,1);
+  testOne(0,1,1,2);
+  testOne(1,2,0,2);
+
+}
+
+void runJITCPPTests() {
+  codeTemplateTest();
+  fusionTests();
+}
+
+}}

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -50,7 +50,7 @@ static void codeTemplateTest() {
     TemplateEnv e;
     e.s("hi","foo");
     e.v("what",{"is","this"});
-    TemplateEnv c(&e);
+    TemplateEnv c(e);
     c.s("hi","foo2");
     JIT_ASSERT(e.s("hi") == "foo");
     JIT_ASSERT(c.s("hi") == "foo2");

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -1,6 +1,10 @@
 #include <iostream>
+#ifdef WITH_CUDA
 #include "torch/csrc/jit/fusion_compiler.h"
+#endif
 #include "torch/csrc/jit/code_template.h"
+#include "torch/csrc/jit/assert.h"
+#include "torch/csrc/jit/ir.h"
 
 namespace torch { namespace jit {
 
@@ -16,7 +20,7 @@ static std::ostream & operator<<(std::ostream & out, const std::vector<T> & list
   out << "}";
   return out;
 }
-using AR = ArrayRef<Node*>;
+using AR = at::ArrayRef<Node*>;
 
 static auto ct = CodeTemplate(R"(
 int foo($args) {
@@ -72,6 +76,7 @@ static void codeTemplateTest() {
   }
 }
 
+#ifdef WITH_CUDA
 static void fusionTests() {
   FusionCompiler comp;
   cudaFree(0);
@@ -153,6 +158,10 @@ static void fusionTests() {
   testOne(1,2,0,2);
 
 }
+#else //WITH_CUDA
+void fusionTests() {}
+#endif
+
 
 void runJITCPPTests() {
   codeTemplateTest();


### PR DESCRIPTION
Approach is based on the approach of THC's `pointwiseApply{1,2,3}` family of kernels,
but doesn't have any dependencies on that code.

Adjacent contiguous dimensions of input tensors are compressed to reduce the complexity of indexing math.
For the completely contiguous case, the indexing logic simplifies to just the linear index.

In simple tests, this code matched or beat the equivalent from THC.

This isn't linked up to the tracer yet, because we need to coordinate how the FusionCompiler will interact with traces to handle caching, and we need to record relevant size/stride info.