### PR TITLE
MNIST traces

### DIFF
--- a/test/expect/TestModels.test_mnist.expect
+++ b/test/expect/TestModels.test_mnist.expect
@@ -1,0 +1,18 @@
+graph(%1 : Double(10, 1, 5, 5), %2 : Double(10), %3 : Double(20, 10, 5, 5), %4 : Double(20), %5 : Double(50, 320), %6 : Double(50), %7 : Double(10, 50), %8 : Double(10), %9 : Double(1000, 1, 28, 28)) {
+  %10.0 : Double(1000, 10, 24, 24) = CppOp[ConvForward](%9, %1, %2), uses = [[%12.i0]];
+  %12.0 : Double(1000, 10, 12, 12), %12.1 : Long(1000, 10, 12, 12) = ^MaxPool2d(2, None, 0, 1, False)(%10.0), uses = [[%15.i0], []];
+  %15.0 : Double(1000, 10, 12, 12) = ^Threshold(0, 0, False)(%12.0), uses = [[%17.i0]];
+  %17.0 : Double(1000, 20, 8, 8) = CppOp[ConvForward](%15.0, %3, %4), uses = [[%19.i0]];
+  %19.0 : Double(1000, 20, 8, 8) = ^FeatureDropout(0.5, True, False)(%17.0), uses = [[%21.i0]];
+  %21.0 : Double(1000, 20, 4, 4), %21.1 : Long(1000, 20, 4, 4) = ^MaxPool2d(2, None, 0, 1, False)(%19.0), uses = [[%24.i0], []];
+  %24.0 : Double(1000, 20, 4, 4) = ^Threshold(0, 0, False)(%21.0), uses = [[%26.i0]];
+  %26.0 : Double(1000, 320) = ^View((-1, 320))(%24.0), uses = [[%30.i1]];
+  %28.0 : Double(320!, 50!) = ^Transpose(0, 1)(%5), uses = [[%30.i2]];
+  %30.0 : Double(1000, 50) = ^Addmm(1, 1, False)(%6, %26.0, %28.0), uses = [[%32.i0]];
+  %32.0 : Double(1000, 50) = ^Threshold(0, 0, False)(%30.0), uses = [[%34.i0]];
+  %34.0 : Double(1000, 50) = ^Dropout(0.5, True, False)(%32.0), uses = [[%38.i1]];
+  %36.0 : Double(50!, 10!) = ^Transpose(0, 1)(%7), uses = [[%38.i2]];
+  %38.0 : Double(1000, 10) = ^Addmm(1, 1, False)(%8, %34.0, %36.0), uses = [[%40.i0]];
+  %40.0 : Double(1000, 10) = ^LogSoftmax()(%38.0), uses = [[%0.i0]];
+  return (%40.0);
+}

--- a/test/model_defs/mnist.py
+++ b/test/model_defs/mnist.py
@@ -1,0 +1,21 @@
+import torch.nn as nn
+import torch.nn.functional as F
+
+class MNIST(nn.Module):
+
+    def __init__(self):
+        super(MNIST, self).__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
+        self.conv2_drop = nn.Dropout2d()
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -3,6 +3,7 @@ import torch.jit
 from torch.autograd import Variable
 from common import TestCase, run_tests
 from model_defs.alexnet import AlexNet
+from model_defs.mnist import MNIST
 from model_defs.vgg import make_layers, VGG, cfg
 from model_defs.resnet import Bottleneck, ResNet
 from model_defs.inception import Inception3
@@ -45,6 +46,13 @@ class TestJit(TestCase):
         trace, _ = torch.jit.record_trace(AlexNet(inplace=inplace), x)
         self.assertExpected(str(trace))
         self.assertExpected(torch._C._jit_pass_export(trace), "pbtxt")
+
+    def test_mnist(self):
+        x = Variable(torch.randn(1000, 1, 28, 28).fill_(1.0),
+                     requires_grad=True)
+        trace, _ = torch.jit.record_trace(MNIST(), x)
+        self.assertExpected(str(trace))
+        #self.assertExpected(torch._C._jit_pass_export(trace), "pbtxt")
 
     def test_vgg(self):
 


### PR DESCRIPTION
PythonOp's primspec returned None, indicating conversion not supported FeatureDropout.
Right now torch._C._jit_pass_export(trace) is commented out.