### PR TITLE
simple fix for the error when stride is None

### DIFF
--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -14,6 +14,7 @@ class MaxPool1d(Function):
                  ceil_mode=False):
         if ceil_mode:
             return None
+        stride = stride or kernel_size
         return torch.toffee.op("MaxPool", input,
                                kernel=kernel_size,
                                stride=stride,
@@ -369,6 +370,7 @@ class AvgPool2d(Function):
                  ceil_mode=False, count_include_pad=True):
         if ceil_mode:
             return None
+        stride = stride or kernel_size
         return torch.toffee.op("AveragePool", input,
                                kernel=kernel_size,
                                stride=stride,


### PR DESCRIPTION
If stride is None, the attribute stride will have no value. So we should set it as the default value kernel size.