### PR TITLE
add dcgan test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -430,7 +430,7 @@ if WITH_TOFFEE:
     conda_info = json.loads(subprocess.check_output(['conda', 'info', '--json']))
     conda_prefix = conda_info['default_prefix']
     toffee_lib = subprocess.check_output(['find', conda_prefix, '-name', 'toffee_cpp2py_export.so'])
-    main_link_args += [toffee_lib.strip()]
+    main_link_args += [str(toffee_lib.strip())]
     include_dirs.append(lib_path + "/ToffeeIR")
     main_sources += [
         "torch/csrc/toffee/export.cpp",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import subprocess
 import shutil
 import sys
 import os
+import json
 
 from tools.setup_helpers.env import check_env_flag
 from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME
@@ -425,11 +426,12 @@ if WITH_CUDNN:
     extra_compile_args += ['-DWITH_CUDNN']
 
 if WITH_TOFFEE:
-    include_dirs.append(tmp_install_path + "/include/toffee")
-    TOFFEE_LIB = os.path.join(lib_path, 'libtoffee.so.1')
-    if platform.system() == 'Darwin':
-        TOFFEE_LIB = os.path.join(lib_path, 'libtoffee.1.dylib')
-    main_link_args += [TOFFEE_LIB]
+    # TODO: MASSIVE HACK TO FIND toffee
+    conda_info = json.loads(subprocess.check_output(['conda', 'info', '--json']))
+    conda_prefix = conda_info['default_prefix']
+    toffee_lib = subprocess.check_output(['find', conda_prefix, '-name', 'toffee_cpp2py_export.so'])
+    main_link_args += [toffee_lib.strip()]
+    include_dirs.append(lib_path + "/ToffeeIR")
     main_sources += [
         "torch/csrc/toffee/export.cpp",
         "torch/csrc/autograd/functions/toffee/convolution.cpp",

--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -44,16 +44,16 @@ BATCH_SIZE = 2
 
 
 class TestCaffe2Backend(unittest.TestCase):
-    def run_model_test(self, model, train, batch_size, x=None):
+    def run_model_test(self, model, train, batch_size, input=None):
         torch.manual_seed(0)
         model.train(train)
 
         # Random (deterministic) input
-        if x is None:
-            x = Variable(torch.randn(batch_size, 3, 224, 224), requires_grad=True)
+        if input is None:
+            input = Variable(torch.randn(batch_size, 3, 224, 224), requires_grad=True)
 
         # Enable tracing on the model
-        trace, torch_out = torch.jit.record_trace(model, x)
+        trace, torch_out = torch.jit.record_trace(model, input)
         proto = torch._C._jit_pass_export(trace)
 
         graph_def = toffee.GraphProto()
@@ -74,7 +74,7 @@ class TestCaffe2Backend(unittest.TestCase):
                 W[v] = torch.zeros(size).numpy()
             else:
                 W[v] = torch.ones(size).numpy()
-        for k, v in zip(real_inputs, itertools.chain(model.parameters(), [x])):
+        for k, v in zip(real_inputs, itertools.chain(model.parameters(), [input])):
             W[k] = v.data.numpy()
 
         caffe2_out_workspace = c2.run_graph(

--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -6,12 +6,15 @@ from __future__ import unicode_literals
 import numpy as np
 import sys
 import itertools
+
 from vgg import *
-from alexnet import *
-from resnet import *
-from mnist import *
-from squeezenet import *
-from inception import *
+from dcgan import *
+from alexnet import AlexNet
+from resnet import Bottleneck, ResNet
+from inception import Inception3
+from squeezenet import SqueezeNet
+from densenet import DenseNet
+
 
 try:
     import caffe2
@@ -37,78 +40,84 @@ import google.protobuf.text_format
 import unittest
 
 
-BATCH_SIZE = 10
-
-# BN -> train mode
-# Dropout -> test mode
-
-# AlexNet - done
-# VGG16 - done [test mode due to Dropout]
-# VGG16-BN - done [train mode but remove Dropout()]
-# VGG19 - done [test mode due to Dropout]
-# VGG19-BN - done [train mode but remove Dropout()]
-# SqueezeNet - done [test mode due to Dropout]
-# ResNet50 - done [train mode]
-# Inception3
-# DCGAN
-#   - netG
-#   - netD
-# DenseNet121
+BATCH_SIZE = 2
 
 
 class TestCaffe2Backend(unittest.TestCase):
-    def test_models(self):
-        # TODO: we run BN in train mode only right now [hard-coded is_test=0]
-        # in primspec. VGG model has Dropout() in train mode so it is recommended
-        # to run it in test mode. VGG-BN model should run in train model only
-        # due to BN but this contradicts Dropout()
+    def run_model_test(self, model, train, batch_size):
+        torch.manual_seed(0)
+        model.train(train)
 
-        # models = [make_vgg16_bn(), make_vgg19_bn()]
-        # models = [make_vgg16(), make_vgg19(), AlexNet()]
-        # models = [resnet50]
-        # resnet50 = ResNet(Bottleneck, [3, 4, 6, 3], inplace=False)
-        sqnet_v1_1 = SqueezeNet(version=1.1, inplace=False)
-        models = [sqnet_v1_1]
+        # Random (deterministic) input
+        x = Variable(torch.randn(batch_size, 3, 224, 224), requires_grad=True)
+
+        # Enable tracing on the model
+        trace, torch_out = torch.jit.record_trace(model, x)
+        proto = torch._C._jit_pass_export(trace)
+
+        graph_def = toffee.GraphProto()
+        google.protobuf.text_format.Merge(proto, graph_def)
+
+        # TODO: This is a hack; PyTorch should set it
+        graph_def.version = toffee.GraphProto().version
+
+        toffee.checker.check_graph(graph_def)
+
+        # Translate the parameters into Caffe2 form
+        W = {}
+        batch_norm_running_values = [s for s in graph_def.input if "saved" in s]
+        real_inputs = [s for s in graph_def.input if "saved" not in s]
+        for v in batch_norm_running_values:
+            size = int(v.split('_')[-2])
+            if "mean" in v:
+                W[v] = torch.zeros(size).numpy()
+            else:
+                W[v] = torch.ones(size).numpy()
+        for k, v in zip(real_inputs, itertools.chain(model.parameters(), [x])):
+            W[k] = v.data.numpy()
+
+        caffe2_out_workspace = c2.run_graph(
+            init_graph=None,
+            predict_graph=graph_def,
+            inputs=W)
+        caffe2_out = list(caffe2_out_workspace.values())[0]
+        np.testing.assert_almost_equal(torch_out.data.numpy(), caffe2_out,
+                                       decimal=3)
+        print('Finished testing model.')
+
+    def test_alexnet(self):
+        alexnet = AlexNet()
+        self.run_model_test(alexnet, train=False,
+                            batch_size=BATCH_SIZE)
+
+    def test_vgg(self):
+        models = [make_vgg16(), make_vgg19()]
         for underlying_model in models:
-            torch.manual_seed(0)
-            underlying_model.train(False)
+            self.run_model_test(underlying_model, train=False,
+                                batch_size=BATCH_SIZE)
 
-            # Random (deterministic) input
-            # x = Variable(torch.randn(BATCH_SIZE, 1, 28, 28), requires_grad=True)
-            x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224), requires_grad=True)
+    def test_vgg_bn(self):
+        models = [make_vgg16_bn(), make_vgg19_bn()]
+        for underlying_model in models:
+            self.run_model_test(underlying_model, train=False,
+                                batch_size=BATCH_SIZE)
 
-            # Enable tracing on the model
-            trace, torch_out = torch.jit.record_trace(underlying_model, x)
-            proto = torch._C._jit_pass_export(trace)
+    def test_resnet(self):
+        resnet50 = ResNet(Bottleneck, [3, 4, 6, 3], inplace=False)
+        self.run_model_test(resnet50, train=False, batch_size=BATCH_SIZE)
 
-            graph_def = toffee.GraphProto()
-            google.protobuf.text_format.Merge(proto, graph_def)
+    def test_squeezenet(self):
+        sqnet_v1_1 = SqueezeNet(version=1.1, inplace=False)
+        self.run_model_test(sqnet_v1_1, train=False, batch_size=BATCH_SIZE)
 
-            # TODO: This is a hack; PyTorch should set it
-            graph_def.version = toffee.GraphProto().version
+    def test_densenet(self):
+        densenet121 = DenseNet(num_init_features=64, growth_rate=32,
+                               block_config=(6, 12, 24, 16), inplace=False)
+        self.run_model_test(densenet121, train=False, batch_size=BATCH_SIZE)
 
-            toffee.checker.check_graph(graph_def)
-
-            # Translate the parameters into Caffe2 form
-            W = {}
-            batch_norm_running_values = [s for s in graph_def.input if "saved" in s]
-            real_inputs = [s for s in graph_def.input if "saved" not in s]
-            for v in batch_norm_running_values:
-                # print(v)
-                size = int(v.split('_')[-2])
-                if "mean" in v:
-                    W[v] = torch.zeros(size).numpy()
-                else:
-                    W[v] = torch.ones(size).numpy()
-            for k, v in zip(real_inputs, itertools.chain(underlying_model.parameters(), [x])):
-                W[k] = v.data.numpy()
-
-            caffe2_out_workspace = c2.run_graph(
-                init_graph=None,
-                predict_graph=graph_def,
-                inputs=W)
-            caffe2_out = list(caffe2_out_workspace.values())[0]
-            np.testing.assert_almost_equal(torch_out.data.numpy(), caffe2_out, decimal=3)
+    def test_inception(self):
+        inception = Inception3(aux_logits=False, inplace=False)
+        self.run_model_test(inception, train=False, batch_size=BATCH_SIZE)
 
 
 if __name__ == '__main__':

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -380,7 +380,15 @@ class Squeeze(InplaceFunction):
     def primspec(input, dim, inplace=False):
         if inplace:
             return None
-        return torch.toffee.op("Squeeze", input, dims=[dim])
+        if dim is None:
+            dim = []
+            for i, size in enumerate(input.size()):
+                if size == 1:
+                    dim.append(i)
+            dim = tuple(dim)
+        else:
+            dim = (dim, )
+        return torch.toffee.op("Squeeze", input, dims=dim)
 
     @staticmethod
     def forward(ctx, input, dim=None, inplace=False):

--- a/torch/csrc/autograd/functions/toffee/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/toffee/batch_normalization.cpp
@@ -27,7 +27,7 @@ void BatchNormForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit
     attr->set_name(name); \
     attr->set_##format(value);
 
-  ADD_ATTR("is_test",i,0);
+  ADD_ATTR("is_test",i,!this->training);
   ADD_ATTR("epsilon",f,eps);
   ADD_ATTR("order",s,"NCHW");
   ADD_ATTR("momentum",f,1-momentum);
@@ -42,17 +42,17 @@ void BatchNormForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit
   ctx->graph->add_input(sm);
   ctx->graph->add_input(sv);
   p_n->add_input(sm);
-  p_n->add_output(sm);
   p_n->add_input(sv);
-  p_n->add_output(sv);
-
-  // dummy output
-  for(int i = 3; i < 5; i++) {
-    p_n->add_output(
-        "batch_norm_dead_output_" + std::to_string(i)+std::to_string(ctx->batch_norm_count)
-    );
+  if(this->training) {
+    p_n->add_output(sm);
+    p_n->add_output(sv);
+    // dummy output
+    for(int i = 3; i < 5; i++) {
+      p_n->add_output(
+          "batch_norm_dead_output_" + std::to_string(i)+std::to_string(ctx->batch_norm_count)
+      );
+    }
   }
-
   ctx->batch_norm_count++;
 }
 

--- a/torch/csrc/autograd/functions/toffee/convolution.cpp
+++ b/torch/csrc/autograd/functions/toffee/convolution.cpp
@@ -4,7 +4,13 @@ namespace torch { namespace autograd {
 
 void ConvForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit::node_list outputs) {
   toffee::NodeProto* p_n = ctx->graph->add_node();
-  p_n->set_op_type("Conv");
+
+  // Here we have two cases: Conv and ConvTranspose.
+  if (transposed == false) {
+    p_n->set_op_type("Conv");
+  } else {
+    p_n->set_op_type("ConvTranspose");
+  }
 
   p_n->add_input(ctx->node(inputs.at(0)));
   p_n->add_input(ctx->node(inputs.at(1)));
@@ -23,45 +29,91 @@ void ConvForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit::nod
   // recorded in ConvForward.  So we have to reverse
   // engineer it from the input types...
   // TODO: dynamic_cast ew
+  // attribute kernel(s).
   auto weight_type = inputs.at(1)->type()->cast<jit::TensorType>();
   JIT_ASSERT(weight_type);
   auto weight_size = weight_type->sizes();
   std::vector<int64_t> kernel_size(weight_size.begin() + 2, weight_size.end());
   attr = p_n->add_attribute();
-  attr->set_name("kernels");
-  for (int kernel : kernel_size) {
-    attr->add_ints(kernel);
+  if (transposed == false) {
+    attr->set_name("kernels");
+    for (int kernel : kernel_size) {
+      attr->add_ints(kernel);
+    }
+  } else {
+    attr->set_name("kernel");
+    JIT_ASSERT(kernel_size.size() >= 1);
+    int kernel_val = kernel_size[0];
+    for (int k : kernel_size) {
+      JIT_ASSERT(k == kernel_val);
+    }
+    attr->set_i(kernel_val);
   }
 
+  // attribute stride(s).
   attr = p_n->add_attribute();
-  attr->set_name("strides");
-  for (int s : stride) {
-    attr->add_ints(s);
+  if (transposed == false) {
+    attr->set_name("strides");
+    for (int s : stride) {
+      attr->add_ints(s);
+    }
+  } else {
+    attr->set_name("stride");
+    JIT_ASSERT(stride.size() >= 1);
+    int stride_val = stride[0];
+    for (int s : stride) {
+      JIT_ASSERT(s == stride_val);
+    }
+    attr->set_i(stride_val);
   }
+
+  // attribute pad(s).
   attr = p_n->add_attribute();
-  attr->set_name("pads");
-  for (int p : padding) {
-    attr->add_ints(p);
+  if (transposed == false) {
+    attr->set_name("pads");
+    for (int p : padding) {
+      attr->add_ints(p);
+    }
+    // NB: Caffe2 let's specifying top and bottom pads separately;
+    // PyTorch assumes it's symmetric
+    for (int p : padding) {
+      attr->add_ints(p);
+    }
+  } else {
+    attr->set_name("pad");
+    JIT_ASSERT(padding.size() >= 1);
+    int padding_val = padding[0];
+    for (int p : padding) {
+      JIT_ASSERT(p == padding_val);
+    }
+    attr->set_i(padding_val);
   }
-  // NB: Caffe2 let's specifying top and bottom pads separately;
-  // PyTorch assumes it's symmetric
-  for (int p : padding) {
-    attr->add_ints(p);
+
+  // attribute dilation(s).
+  if (transposed == false) {
+    attr = p_n->add_attribute();
+    attr->set_name("dilations");
+    for (int d : dilation) {
+      attr->add_ints(d);
+    }
+  } else {
+    // ConvTranspose in Caffe2 only supports dilation=1.
+    for (int d : dilation) {
+      JIT_ASSERT(d == 1);
+    }
   }
-  attr = p_n->add_attribute();
-  attr->set_name("dilations");
-  for (int d : dilation) {
-    attr->add_ints(d);
-  }
-  // Not in Toffee?
-  JIT_ASSERT(transposed == false);
+
+  // Caffe2 does not support output_padding.
   for (int p : output_padding) {
     JIT_ASSERT(p == 0);
   }
-  attr = p_n->add_attribute();
-  attr->set_name("group");
-  attr->set_i(groups);
-  // ignore benchmark/cudnn_enabled
+
+  if (transposed == false) {
+    attr = p_n->add_attribute();
+    attr->set_name("group");
+    attr->set_i(groups);
+    // ignore benchmark/cudnn_enabled
+  }
 }
 
 }}

--- a/torch/csrc/autograd/functions/toffee/convolution.cpp
+++ b/torch/csrc/autograd/functions/toffee/convolution.cpp
@@ -41,6 +41,7 @@ void ConvForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit::nod
       attr->add_ints(kernel);
     }
   } else {
+    // ConvTranspose in caffe2 only supports kernel.
     attr->set_name("kernel");
     JIT_ASSERT(kernel_size.size() >= 1);
     int kernel_val = kernel_size[0];
@@ -58,6 +59,7 @@ void ConvForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit::nod
       attr->add_ints(s);
     }
   } else {
+    // ConvTranspose in caffe2 only supports stride.
     attr->set_name("stride");
     JIT_ASSERT(stride.size() >= 1);
     int stride_val = stride[0];
@@ -80,6 +82,7 @@ void ConvForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit::nod
       attr->add_ints(p);
     }
   } else {
+    // ConvTranspose in caffe2 only supports pad.
     attr->set_name("pad");
     JIT_ASSERT(padding.size() >= 1);
     int padding_val = padding[0];
@@ -98,6 +101,7 @@ void ConvForward::primspec(PrimSpecContext* ctx, jit::node_list inputs, jit::nod
     }
   } else {
     // ConvTranspose in Caffe2 only supports dilation=1.
+    // So we have a sanity check here.
     for (int d : dilation) {
       JIT_ASSERT(d == 1);
     }

--- a/torch/csrc/toffee/export.cpp
+++ b/torch/csrc/toffee/export.cpp
@@ -4,7 +4,7 @@
 #include "torch/csrc/Exceptions.h"
 
 #include <toffee/toffee.pb.h>
-#include <toffee/schema.h>
+#include <toffee/defs/schema.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -144,7 +144,7 @@ build THPP
 build libshm
 build ATen
 if [[ $WITH_TOFFEE -eq 1 ]]; then
-    build ToffeeIR
+    (cd torch/lib/ToffeeIR; python setup.py install);
 fi
 
 # THD, gloo have dependencies on Torch, CUDA, NCCL etc.

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -144,7 +144,7 @@ build THPP
 build libshm
 build ATen
 if [[ $WITH_TOFFEE -eq 1 ]]; then
-    (cd torch/lib/ToffeeIR; python setup.py install);
+    (cd ToffeeIR; python setup.py install);
 fi
 
 # THD, gloo have dependencies on Torch, CUDA, NCCL etc.

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -14,6 +14,7 @@ class MaxPool1d(Function):
                  ceil_mode=False):
         if ceil_mode:
             return None
+        stride = stride or kernel_size
         return torch.toffee.op("MaxPool", input,
                                kernel=kernel_size,
                                stride=stride,
@@ -369,6 +370,7 @@ class AvgPool2d(Function):
                  ceil_mode=False, count_include_pad=True):
         if ceil_mode:
             return None
+        stride = stride or kernel_size
         return torch.toffee.op("AveragePool", input,
                                kernel=kernel_size,
                                stride=stride,


### PR DESCRIPTION
This commit actually does three things:
1) Add support for ConvTranspose op in torch/csrc/autograd/functions/toffee/convolution.cpp. So we can support ConvTranspose2d which is used by the dcgan model.
2) Fix the dim primspec for Squeeze op.
3) Add dcgan pytorch-caffe2 test.