### PR TITLE
Faster tensor serialization.

### DIFF
--- a/torch/csrc/toffee.cpp
+++ b/torch/csrc/toffee.cpp
@@ -23,6 +23,23 @@ bool micropb_encode<double, nullptr>(pb_ostream_t *stream, double* arg) {
   return pb_encode_fixed64(stream, static_cast<void*>(arg));
 }
 
+// TODO: I'm not entirely sure why this can't be in the header...
+bool micropb_callback_tensor(pb_ostream_t *stream, const pb_field_t *field, void * const *arg) {
+  at::Tensor* t = static_cast<at::Tensor*>(*arg);
+  JIT_ASSERT(t->type().scalarType() == at::kFloat);
+  JIT_ASSERT(t->is_contiguous());
+  // TODO: Generalize beyond float
+  // Packed array format!
+  pb_encode_tag(stream, PB_WT_STRING, toffee_TensorProto_float_data_tag);
+  pb_encode_varint(stream, 4 * t->numel()); // number of bytes to write
+  // TODO: If you have a better way of doing this, I'm all ears.
+  float *addr = t->data<float>();
+  for (float *p = addr; p < addr + t->numel(); p++) {
+    if (!pb_encode_fixed32(stream, static_cast<void*>(p))) return false;
+  }
+  return true;
+}
+
 GraphProto* AttributeProto::add_graphs() {
   auto ptr = new GraphProto();
   graphs.emplace_back(ptr);

--- a/torch/csrc/toffee/export.cpp
+++ b/torch/csrc/toffee/export.cpp
@@ -8,6 +8,7 @@
 #include "torch/csrc/autograd/functions/convolution.h"
 #include "torch/csrc/jit/dead_code_elimination.h"
 #include "torch/csrc/utils/functional.h"
+#include <ATen/ATen.h>
 
 #include <fstream>
 #undef NDEBUG
@@ -168,11 +169,7 @@ static void encodeTensor(toffee::TensorProto * p, const at::Tensor & tensor) {
     p->set_data_type(toffee::TensorProto_DataType_FLOAT);
     //TODO: other types, we force conversion here
     at::Tensor cont = tensor.toType(at::CPU(at::kFloat));
-    float * data = cont.data<float>();
-    int64_t N = cont.numel();
-    for(int64_t i = 0; i < N; ++i) {
-      p->add_float_data(data[i]);
-    }
+    p->add_tensor(cont);
 }
 static void encodeGraph(toffee::GraphProto * p_g, std::shared_ptr<Graph> & g, const std::vector<at::Tensor> & initializers);
 static void addAttribute(toffee::NodeProto * n_p, jit::Node * n, jit::Symbol name) {


### PR DESCRIPTION
Instead of dynamically allocating a float for each element of the tensor
(lol!) save the tensor itself, and directly read out the data.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>