### PR TITLE
Enabling C2 side e2e test for models

### DIFF
--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -119,17 +119,20 @@ class TestCaffe2Backend(unittest.TestCase):
         self.run_model_test(vgg16, train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict)
 
+    @skip("disable to run tests faster...")
     def test_vgg16_bn(self):
         underlying_model = make_vgg16_bn()
         self.run_model_test(underlying_model, train=False,
                             batch_size=BATCH_SIZE)
 
+    @skip("disable to run tests faster...")
     def test_vgg19(self):
         vgg19 = make_vgg19()
         state_dict = model_zoo.load_url(model_urls['vgg19'])
         self.run_model_test(vgg19, train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict)
 
+    @skip("disable to run tests faster...")
     def test_vgg19_bn(self):
         underlying_model = make_vgg19_bn()
         self.run_model_test(underlying_model, train=False,

--- a/test/model_defs/wrapper.py
+++ b/test/model_defs/wrapper.py
@@ -58,7 +58,9 @@ def torch_export(model, x):
     return proto, torch_out
 
 
-def caffe2_load(proto, model, x, state_dict=None, use_gpu=False):
+def caffe2_load(proto, model, x, state_dict=None, use_gpu=True):
+    if not torch.cuda.is_available():
+        use_gpu = False
 
     ts4 = timeit.default_timer()
     graph_def = toffee.GraphProto.FromString(proto)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -44,7 +44,6 @@ class TestModels(TestCase):
         )
         trace, _ = torch.jit.record_trace(toC(DummyNet(inplace=inplace)), toC(x))
         self.assertExpected(str(trace))
-        proto = torch._C._jit_pass_export(trace)
         self.assertToffeeExpected(torch._C._jit_pass_export(trace), "pbtxt")
 
     def test_concat(self):


### PR DESCRIPTION
We don't see much gains from using cuda run on C2 side. This is perhaps because the overhead of launching and running on same gpu is too much

but I disabled 3 vgg test which aren't really required. one vgg test is enough to catch any breaking changes. this makes all tests run in 30sec now!