### PR TITLE
switch to using raw_data in PB

### DIFF
--- a/gen_toffee.sh
+++ b/gen_toffee.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+set -x
 # Assumed to be run like ./gen_toffee.sh
 (cd torch/lib/nanopb/generator/proto && make)
 protoc --plugin=protoc-gen-nanopb=$PWD/torch/lib/nanopb/generator/protoc-gen-nanopb \

--- a/test/expect/TestJit.test_export_data.expect
+++ b/test/expect/TestJit.test_export_data.expect
@@ -37,9 +37,6 @@ initializer {
   dims: 2
   dims: 2
   data_type: FLOAT
-  float_data: 1
-  float_data: 2
-  float_data: 3
-  float_data: 4
   name: "1"
+  raw_data: "\000\000\200?\000\000\000@\000\000@@\000\000\200@"
 }

--- a/torch/csrc/toffee.cpp
+++ b/torch/csrc/toffee.cpp
@@ -30,14 +30,9 @@ bool micropb_callback_tensor(pb_ostream_t *stream, const pb_field_t *field, void
   JIT_ASSERT(t->is_contiguous());
   // TODO: Generalize beyond float
   // Packed array format!
-  pb_encode_tag(stream, PB_WT_STRING, toffee_TensorProto_float_data_tag);
-  static_assert(sizeof(float) == 4, "float is not four bytes");
-  pb_encode_varint(stream, sizeof(float) * t->numel()); // number of bytes to write
-  // TODO: If you have a better way of doing this, I'm all ears.
-  float *addr = t->data<float>();
-  for (float *p = addr; p < addr + t->numel(); p++) {
-    if (!pb_encode_fixed32(stream, static_cast<void*>(p))) return false;
-  }
+  pb_encode_tag_for_field(stream, field);
+  pb_encode_string(stream, (pb_byte_t*)(t->data_ptr()),  sizeof(float)*t->numel());
+
   return true;
 }
 

--- a/torch/csrc/toffee.h
+++ b/torch/csrc/toffee.h
@@ -153,7 +153,7 @@ public:
   void add_dims(int64_t d) { dims.emplace_back(new int64_t(d)); }
   void add_tensor(const at::Tensor& t) {
     if (t.type().scalarType() == at::kFloat) {
-      proto.float_data = tensor(&tensor_data, t);
+      proto.raw_data = tensor(&tensor_data, t);
     } else {
       JIT_ASSERTM(0, "non-float tensors not supported yet");
     }

--- a/torch/csrc/toffee.pb.cpp
+++ b/torch/csrc/toffee.pb.cpp
@@ -42,7 +42,7 @@ const pb_field_t toffee_GraphProto_fields[7] = {
     PB_LAST_FIELD
 };
 
-const pb_field_t toffee_TensorProto_fields[10] = {
+const pb_field_t toffee_TensorProto_fields[11] = {
     PB_FIELD(  1, INT64   , REPEATED, CALLBACK, FIRST, toffee_TensorProto, dims, dims, 0),
     PB_FIELD(  2, UENUM   , OPTIONAL, STATIC  , OTHER, toffee_TensorProto, data_type, dims, 0),
     PB_FIELD(  3, FLOAT   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, float_data, data_type, 0),
@@ -52,6 +52,7 @@ const pb_field_t toffee_TensorProto_fields[10] = {
     PB_FIELD(  7, INT64   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, int64_data, string_data, 0),
     PB_FIELD(  8, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_TensorProto, name, int64_data, 0),
     PB_FIELD(  9, MESSAGE , OPTIONAL, STATIC  , OTHER, toffee_TensorProto, segment, name, &toffee_TensorProto_Segment_fields),
+    PB_FIELD( 10, BYTES   , OPTIONAL, CALLBACK, OTHER, toffee_TensorProto, raw_data, segment, 0),
     PB_LAST_FIELD
 };
 

--- a/torch/csrc/toffee.pb.h
+++ b/torch/csrc/toffee.pb.h
@@ -96,6 +96,7 @@ typedef struct _toffee_TensorProto {
     pb_callback_t name;
     bool has_segment;
     toffee_TensorProto_Segment segment;
+    pb_callback_t raw_data;
 /* @@protoc_insertion_point(struct:toffee_TensorProto) */
 } toffee_TensorProto;
 
@@ -114,13 +115,13 @@ typedef struct _toffee_SparseTensorProto {
 #define toffee_AttributeProto_init_default       {{{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
 #define toffee_NodeProto_init_default            {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
 #define toffee_GraphProto_init_default           {false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_TensorProto_init_default          {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, toffee_TensorProto_Segment_init_default}
+#define toffee_TensorProto_init_default          {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, toffee_TensorProto_Segment_init_default, {{NULL}, NULL}}
 #define toffee_TensorProto_Segment_init_default  {false, 0, false, 0}
 #define toffee_SparseTensorProto_init_default    {{{NULL}, NULL}, false, toffee_TensorProto_init_default, false, toffee_TensorProto_init_default}
 #define toffee_AttributeProto_init_zero          {{{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
 #define toffee_NodeProto_init_zero               {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
 #define toffee_GraphProto_init_zero              {false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_TensorProto_init_zero             {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, toffee_TensorProto_Segment_init_zero}
+#define toffee_TensorProto_init_zero             {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, toffee_TensorProto_Segment_init_zero, {{NULL}, NULL}}
 #define toffee_TensorProto_Segment_init_zero     {false, 0, false, 0}
 #define toffee_SparseTensorProto_init_zero       {{{NULL}, NULL}, false, toffee_TensorProto_init_zero, false, toffee_TensorProto_init_zero}
 
@@ -156,6 +157,7 @@ typedef struct _toffee_SparseTensorProto {
 #define toffee_TensorProto_int64_data_tag        7
 #define toffee_TensorProto_name_tag              8
 #define toffee_TensorProto_segment_tag           9
+#define toffee_TensorProto_raw_data_tag          10
 #define toffee_SparseTensorProto_dims_tag        1
 #define toffee_SparseTensorProto_indices_tag     2
 #define toffee_SparseTensorProto_values_tag      3
@@ -164,7 +166,7 @@ typedef struct _toffee_SparseTensorProto {
 extern const pb_field_t toffee_AttributeProto_fields[10];
 extern const pb_field_t toffee_NodeProto_fields[6];
 extern const pb_field_t toffee_GraphProto_fields[7];
-extern const pb_field_t toffee_TensorProto_fields[10];
+extern const pb_field_t toffee_TensorProto_fields[11];
 extern const pb_field_t toffee_TensorProto_Segment_fields[3];
 extern const pb_field_t toffee_SparseTensorProto_fields[4];
 


### PR DESCRIPTION
Switches to using raw_data in tensor objects. This is an around 20x speedup over using the repeated fields and does not require the cpp implementation of protobuffers.

Depends on https://github.com/ProjectToffee/ToffeeIR/pull/61 do not merge until it is merged.