### PR TITLE
Use https instead of git protocol for Toffee

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,5 +9,5 @@
 	url = https://github.com/nanopb/nanopb.git
 [submodule "torch/lib/ToffeeIR"]
 	path = torch/lib/ToffeeIR
-	url = git@github.com:ProjectToffee/ToffeeIR.git
+	url = https://github.com/ProjectToffee/ToffeeIR.git
 	branch = jit


### PR DESCRIPTION
git requires having ssh keys configured on your machine, while with https you can just use personal access tokens