### PR TITLE
[DO NOT MERGE] Repro weirdness with the Inception test - weight init

### DIFF
--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -68,6 +68,7 @@ class TestCaffe2Backend(unittest.TestCase):
         np.testing.assert_almost_equal(torch_out.data.cpu().numpy(),
                                        caffe2_out, decimal=3)
 
+
     def test_alexnet(self):
         alexnet = AlexNet()
         state_dict = model_zoo.load_url(model_urls['alexnet'])
@@ -146,9 +147,11 @@ class TestCaffe2Backend(unittest.TestCase):
 
 # add the same test suite as above, but switch embed_params=False
 # to embed_params=True
+embed_params = False
+
 TestCaffe2BackendEmbed = type(str("TestCaffe2BackendEmbed"),
                               (unittest.TestCase,),
-                              dict(TestCaffe2Backend.__dict__, embed_params=True))
+                              dict(TestCaffe2Backend.__dict__, embed_params=embed_params))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -96,13 +96,16 @@ class TestCaffe2Backend(unittest.TestCase):
         self.run_model_test(densenet121, train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict)
 
-    @skip("doesn't match exactly, pytorch impl. is incorrect...")
+    # @skip("doesn't match exactly...")
     def test_inception(self):
-        inception = Inception3(aux_logits=True)
+        torch.manual_seed(0)
+        inception = Inception3(aux_logits=True, transform_input=False)
         # state_dict = model_zoo.load_url(model_urls['inception_v3_google'])
         state_dict = None
+        input = Variable(torch.randn(BATCH_SIZE, 3, 299, 299),
+                         requires_grad=True)
         self.run_model_test(inception, train=False, batch_size=BATCH_SIZE,
-                            state_dict=state_dict)
+                            state_dict=state_dict, input=input)
 
     def test_resnet(self):
         resnet50 = ResNet(Bottleneck, [3, 4, 6, 3], inplace=False)

--- a/test/model_defs/inception.py
+++ b/test/model_defs/inception.py
@@ -2,6 +2,7 @@ import torch
 import torch.jit
 import torch.nn as nn
 import torch.nn.functional as F
+import numpy as np
 
 
 class Inception3(nn.Module):
@@ -35,8 +36,10 @@ class Inception3(nn.Module):
                 import scipy.stats as stats
                 stddev = m.stddev if hasattr(m, 'stddev') else 0.1
                 X = stats.truncnorm(-2, 2, scale=stddev)
-                values = torch.Tensor(X.rvs(m.weight.data.numel()))
+                values = torch.Tensor(X.rvs(m.weight.data.numel())).view_as(m.weight.data)
                 m.weight.data.copy_(values)
+                # # the below weight init succeeds but above one fails
+                # m.weight.data.normal_(0.0, 0.02)
             if isinstance(m, nn.BatchNorm2d):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()

--- a/test/model_defs/inception.py
+++ b/test/model_defs/inception.py
@@ -4,253 +4,15 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-class BasicConv2d(nn.Module):
-
-    def __init__(self, in_channels, out_channels, inplace=False, **kwargs):
-        super(BasicConv2d, self).__init__()
-        self.inplace = inplace
-        self.conv = nn.Conv2d(
-            in_channels, out_channels, bias=False, **kwargs)
-        self.bn = nn.BatchNorm2d(out_channels, eps=0.001)
-
-    def forward(self, x):
-        x = self.conv(x)
-        x = self.bn(x)
-        return F.relu(x, inplace=self.inplace)
-
-
-class InceptionA(nn.Module):
-
-    def __init__(self, in_channels, pool_features):
-        super(InceptionA, self).__init__()
-        self.branch1x1 = BasicConv2d(in_channels, 64, kernel_size=1)
-
-        self.branch5x5_1 = BasicConv2d(in_channels, 48, kernel_size=1)
-        self.branch5x5_2 = BasicConv2d(
-            48, 64, kernel_size=5, padding=2)
-
-        self.branch3x3dbl_1 = BasicConv2d(
-            in_channels, 64, kernel_size=1)
-        self.branch3x3dbl_2 = BasicConv2d(
-            64, 96, kernel_size=3, padding=1)
-        self.branch3x3dbl_3 = BasicConv2d(
-            96, 96, kernel_size=3, padding=1)
-
-        self.branch_pool = BasicConv2d(
-            in_channels, pool_features, kernel_size=1)
-
-    def forward(self, x):
-        branch1x1 = self.branch1x1(x)
-
-        branch5x5 = self.branch5x5_1(x)
-        branch5x5 = self.branch5x5_2(branch5x5)
-
-        branch3x3dbl = self.branch3x3dbl_1(x)
-        branch3x3dbl = self.branch3x3dbl_2(branch3x3dbl)
-        branch3x3dbl = self.branch3x3dbl_3(branch3x3dbl)
-
-        branch_pool = F.avg_pool2d(
-            x, kernel_size=3, stride=1, padding=1)
-        branch_pool = self.branch_pool(branch_pool)
-
-        outputs = [branch1x1, branch5x5, branch3x3dbl, branch_pool]
-        return torch.cat(outputs, 1)
-
-
-class InceptionB(nn.Module):
-
-    def __init__(self, in_channels):
-        super(InceptionB, self).__init__()
-        self.branch3x3 = BasicConv2d(
-            in_channels, 384, kernel_size=3, stride=2)
-
-        self.branch3x3dbl_1 = BasicConv2d(
-            in_channels, 64, kernel_size=1)
-        self.branch3x3dbl_2 = BasicConv2d(
-            64, 96, kernel_size=3, padding=1)
-        self.branch3x3dbl_3 = BasicConv2d(
-            96, 96, kernel_size=3, stride=2)
-
-    def forward(self, x):
-        branch3x3 = self.branch3x3(x)
-
-        branch3x3dbl = self.branch3x3dbl_1(x)
-        branch3x3dbl = self.branch3x3dbl_2(branch3x3dbl)
-        branch3x3dbl = self.branch3x3dbl_3(branch3x3dbl)
-
-        branch_pool = F.max_pool2d(x, kernel_size=3, stride=2)
-
-        outputs = [branch3x3, branch3x3dbl, branch_pool]
-        return torch.cat(outputs, 1)
-
-
-class InceptionC(nn.Module):
-
-    def __init__(self, in_channels, channels_7x7):
-        super(InceptionC, self).__init__()
-        self.branch1x1 = BasicConv2d(in_channels, 192, kernel_size=1)
-
-        c7 = channels_7x7
-        self.branch7x7_1 = BasicConv2d(in_channels, c7, kernel_size=1)
-        self.branch7x7_2 = BasicConv2d(
-            c7, c7, kernel_size=(1, 7), padding=(0, 3))
-        self.branch7x7_3 = BasicConv2d(
-            c7, 192, kernel_size=(7, 1), padding=(3, 0))
-
-        self.branch7x7dbl_1 = BasicConv2d(
-            in_channels, c7, kernel_size=1)
-        self.branch7x7dbl_2 = BasicConv2d(
-            c7, c7, kernel_size=(7, 1), padding=(3, 0))
-        self.branch7x7dbl_3 = BasicConv2d(
-            c7, c7, kernel_size=(1, 7), padding=(0, 3))
-        self.branch7x7dbl_4 = BasicConv2d(
-            c7, c7, kernel_size=(7, 1), padding=(3, 0))
-        self.branch7x7dbl_5 = BasicConv2d(
-            c7, 192, kernel_size=(1, 7), padding=(0, 3))
-
-        self.branch_pool = BasicConv2d(in_channels, 192, kernel_size=1)
-
-    def forward(self, x):
-        branch1x1 = self.branch1x1(x)
-
-        branch7x7 = self.branch7x7_1(x)
-        branch7x7 = self.branch7x7_2(branch7x7)
-        branch7x7 = self.branch7x7_3(branch7x7)
-
-        branch7x7dbl = self.branch7x7dbl_1(x)
-        branch7x7dbl = self.branch7x7dbl_2(branch7x7dbl)
-        branch7x7dbl = self.branch7x7dbl_3(branch7x7dbl)
-        branch7x7dbl = self.branch7x7dbl_4(branch7x7dbl)
-        branch7x7dbl = self.branch7x7dbl_5(branch7x7dbl)
-
-        branch_pool = F.avg_pool2d(
-            x, kernel_size=3, stride=1, padding=1)
-        branch_pool = self.branch_pool(branch_pool)
-
-        outputs = [branch1x1, branch7x7, branch7x7dbl, branch_pool]
-        return torch.cat(outputs, 1)
-
-
-class InceptionD(nn.Module):
-
-    def __init__(self, in_channels):
-        super(InceptionD, self).__init__()
-        self.branch3x3_1 = BasicConv2d(in_channels, 192, kernel_size=1)
-        self.branch3x3_2 = BasicConv2d(
-            192, 320, kernel_size=3, stride=2)
-        self.branch7x7x3_1 = BasicConv2d(
-            in_channels, 192, kernel_size=1)
-        self.branch7x7x3_2 = BasicConv2d(
-            192, 192, kernel_size=(1, 7), padding=(0, 3))
-        self.branch7x7x3_3 = BasicConv2d(
-            192, 192, kernel_size=(7, 1), padding=(3, 0))
-        self.branch7x7x3_4 = BasicConv2d(
-            192, 192, kernel_size=3, stride=2)
-
-    def forward(self, x):
-        branch3x3 = self.branch3x3_1(x)
-        branch3x3 = self.branch3x3_2(branch3x3)
-
-        branch7x7x3 = self.branch7x7x3_1(x)
-        branch7x7x3 = self.branch7x7x3_2(branch7x7x3)
-        branch7x7x3 = self.branch7x7x3_3(branch7x7x3)
-        branch7x7x3 = self.branch7x7x3_4(branch7x7x3)
-
-        branch_pool = F.max_pool2d(x, kernel_size=3, stride=2)
-        outputs = [branch3x3, branch7x7x3, branch_pool]
-        return torch.cat(outputs, 1)
-
-
-class InceptionE(nn.Module):
-
-    def __init__(self, in_channels):
-        super(InceptionE, self).__init__()
-        self.branch1x1 = BasicConv2d(in_channels, 320, kernel_size=1)
-
-        self.branch3x3_1 = BasicConv2d(in_channels, 384, kernel_size=1)
-        self.branch3x3_2a = BasicConv2d(
-            384, 384, kernel_size=(1, 3), padding=(0, 1))
-        self.branch3x3_2b = BasicConv2d(
-            384, 384, kernel_size=(3, 1), padding=(1, 0))
-        self.branch3x3dbl_1 = BasicConv2d(
-            in_channels, 448, kernel_size=1)
-        self.branch3x3dbl_2 = BasicConv2d(
-            448, 384, kernel_size=3, padding=1)
-        self.branch3x3dbl_3a = BasicConv2d(
-            384, 384, kernel_size=(1, 3), padding=(0, 1))
-        self.branch3x3dbl_3b = BasicConv2d(
-            384, 384, kernel_size=(3, 1), padding=(1, 0))
-
-        self.branch_pool = BasicConv2d(in_channels, 192, kernel_size=1)
-
-    def forward(self, x):
-        branch1x1 = self.branch1x1(x)
-
-        branch3x3 = self.branch3x3_1(x)
-        branch3x3 = [
-            self.branch3x3_2a(branch3x3),
-            self.branch3x3_2b(branch3x3),
-        ]
-        branch3x3 = torch.cat(branch3x3, 1)
-
-        branch3x3dbl = self.branch3x3dbl_1(x)
-        branch3x3dbl = self.branch3x3dbl_2(branch3x3dbl)
-        branch3x3dbl = [
-            self.branch3x3dbl_3a(branch3x3dbl),
-            self.branch3x3dbl_3b(branch3x3dbl),
-        ]
-        branch3x3dbl = torch.cat(branch3x3dbl, 1)
-
-        branch_pool = F.avg_pool2d(
-            x, kernel_size=3, stride=1, padding=1
-        )
-        branch_pool = self.branch_pool(branch_pool)
-
-        outputs = [branch1x1, branch3x3, branch3x3dbl, branch_pool]
-        return torch.cat(outputs, 1)
-
-
-class InceptionAux(nn.Module):
-
-    def __init__(self, in_channels, num_classes):
-        super(InceptionAux, self).__init__()
-        self.conv0 = BasicConv2d(in_channels, 128, kernel_size=1)
-        self.conv1 = BasicConv2d(128, 768, kernel_size=3)
-        self.conv1.stddev = 0.01
-        self.fc = nn.Linear(768, num_classes)
-        self.fc.stddev = 0.001
-
-    def forward(self, x):
-        # 17 x 17 x 768
-        x = F.avg_pool2d(x, kernel_size=5, stride=3)
-        # 5 x 5 x 768
-        x = self.conv0(x)
-        # 5 x 5 x 128
-        x = self.conv1(x)
-        # 1 x 1 x 768
-        x = x.view(x.size(0), -1)
-        # 768
-        x = self.fc(x)
-        # 1000
-        return x
-
-
 class Inception3(nn.Module):
 
-    def __init__(
-        self, num_classes=1000, aux_logits=True, transform_input=False,
-        inplace=False
-    ):
+    def __init__(self, num_classes=1000, aux_logits=True, transform_input=False):
         super(Inception3, self).__init__()
         self.aux_logits = aux_logits
         self.transform_input = transform_input
-        self.Conv2d_1a_3x3 = BasicConv2d(
-            3, 32, kernel_size=3, stride=2
-        )
+        self.Conv2d_1a_3x3 = BasicConv2d(3, 32, kernel_size=3, stride=2)
         self.Conv2d_2a_3x3 = BasicConv2d(32, 32, kernel_size=3)
-        self.Conv2d_2b_3x3 = BasicConv2d(
-            32, 64, kernel_size=3, padding=1
-        )
+        self.Conv2d_2b_3x3 = BasicConv2d(32, 64, kernel_size=3, padding=1)
         self.Conv2d_3b_1x1 = BasicConv2d(64, 80, kernel_size=1)
         self.Conv2d_4a_3x3 = BasicConv2d(80, 192, kernel_size=3)
         self.Mixed_5b = InceptionA(192, pool_features=32)
@@ -275,7 +37,7 @@ class Inception3(nn.Module):
                 X = stats.truncnorm(-2, 2, scale=stddev)
                 values = torch.Tensor(X.rvs(m.weight.data.numel()))
                 m.weight.data.copy_(values)
-            elif isinstance(m, nn.BatchNorm2d):
+            if isinstance(m, nn.BatchNorm2d):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()
 
@@ -325,7 +87,7 @@ class Inception3(nn.Module):
         # 8 x 8 x 2048
         x = self.Mixed_7c(x)
         # 8 x 8 x 2048
-        x = F.avg_pool2d(x, kernel_size=5)
+        x = F.avg_pool2d(x, kernel_size=8)
         # 1 x 1 x 2048
         x = F.dropout(x, training=self.training)
         # 1 x 1 x 2048
@@ -336,3 +98,203 @@ class Inception3(nn.Module):
         if self.training and self.aux_logits:
             return x, aux
         return x
+
+
+class InceptionA(nn.Module):
+
+    def __init__(self, in_channels, pool_features):
+        super(InceptionA, self).__init__()
+        self.branch1x1 = BasicConv2d(in_channels, 64, kernel_size=1)
+
+        self.branch5x5_1 = BasicConv2d(in_channels, 48, kernel_size=1)
+        self.branch5x5_2 = BasicConv2d(48, 64, kernel_size=5, padding=2)
+
+        self.branch3x3dbl_1 = BasicConv2d(in_channels, 64, kernel_size=1)
+        self.branch3x3dbl_2 = BasicConv2d(64, 96, kernel_size=3, padding=1)
+        self.branch3x3dbl_3 = BasicConv2d(96, 96, kernel_size=3, padding=1)
+
+        self.branch_pool = BasicConv2d(in_channels, pool_features, kernel_size=1)
+
+    def forward(self, x):
+        branch1x1 = self.branch1x1(x)
+
+        branch5x5 = self.branch5x5_1(x)
+        branch5x5 = self.branch5x5_2(branch5x5)
+
+        branch3x3dbl = self.branch3x3dbl_1(x)
+        branch3x3dbl = self.branch3x3dbl_2(branch3x3dbl)
+        branch3x3dbl = self.branch3x3dbl_3(branch3x3dbl)
+
+        branch_pool = F.avg_pool2d(x, kernel_size=3, stride=1, padding=1)
+        branch_pool = self.branch_pool(branch_pool)
+
+        outputs = [branch1x1, branch5x5, branch3x3dbl, branch_pool]
+        return torch.cat(outputs, 1)
+
+
+class InceptionB(nn.Module):
+
+    def __init__(self, in_channels):
+        super(InceptionB, self).__init__()
+        self.branch3x3 = BasicConv2d(in_channels, 384, kernel_size=3, stride=2)
+
+        self.branch3x3dbl_1 = BasicConv2d(in_channels, 64, kernel_size=1)
+        self.branch3x3dbl_2 = BasicConv2d(64, 96, kernel_size=3, padding=1)
+        self.branch3x3dbl_3 = BasicConv2d(96, 96, kernel_size=3, stride=2)
+
+    def forward(self, x):
+        branch3x3 = self.branch3x3(x)
+
+        branch3x3dbl = self.branch3x3dbl_1(x)
+        branch3x3dbl = self.branch3x3dbl_2(branch3x3dbl)
+        branch3x3dbl = self.branch3x3dbl_3(branch3x3dbl)
+
+        branch_pool = F.max_pool2d(x, kernel_size=3, stride=2)
+
+        outputs = [branch3x3, branch3x3dbl, branch_pool]
+        return torch.cat(outputs, 1)
+
+
+class InceptionC(nn.Module):
+
+    def __init__(self, in_channels, channels_7x7):
+        super(InceptionC, self).__init__()
+        self.branch1x1 = BasicConv2d(in_channels, 192, kernel_size=1)
+
+        c7 = channels_7x7
+        self.branch7x7_1 = BasicConv2d(in_channels, c7, kernel_size=1)
+        self.branch7x7_2 = BasicConv2d(c7, c7, kernel_size=(1, 7), padding=(0, 3))
+        self.branch7x7_3 = BasicConv2d(c7, 192, kernel_size=(7, 1), padding=(3, 0))
+
+        self.branch7x7dbl_1 = BasicConv2d(in_channels, c7, kernel_size=1)
+        self.branch7x7dbl_2 = BasicConv2d(c7, c7, kernel_size=(7, 1), padding=(3, 0))
+        self.branch7x7dbl_3 = BasicConv2d(c7, c7, kernel_size=(1, 7), padding=(0, 3))
+        self.branch7x7dbl_4 = BasicConv2d(c7, c7, kernel_size=(7, 1), padding=(3, 0))
+        self.branch7x7dbl_5 = BasicConv2d(c7, 192, kernel_size=(1, 7), padding=(0, 3))
+
+        self.branch_pool = BasicConv2d(in_channels, 192, kernel_size=1)
+
+    def forward(self, x):
+        branch1x1 = self.branch1x1(x)
+
+        branch7x7 = self.branch7x7_1(x)
+        branch7x7 = self.branch7x7_2(branch7x7)
+        branch7x7 = self.branch7x7_3(branch7x7)
+
+        branch7x7dbl = self.branch7x7dbl_1(x)
+        branch7x7dbl = self.branch7x7dbl_2(branch7x7dbl)
+        branch7x7dbl = self.branch7x7dbl_3(branch7x7dbl)
+        branch7x7dbl = self.branch7x7dbl_4(branch7x7dbl)
+        branch7x7dbl = self.branch7x7dbl_5(branch7x7dbl)
+
+        branch_pool = F.avg_pool2d(x, kernel_size=3, stride=1, padding=1)
+        branch_pool = self.branch_pool(branch_pool)
+
+        outputs = [branch1x1, branch7x7, branch7x7dbl, branch_pool]
+        return torch.cat(outputs, 1)
+
+
+class InceptionD(nn.Module):
+
+    def __init__(self, in_channels):
+        super(InceptionD, self).__init__()
+        self.branch3x3_1 = BasicConv2d(in_channels, 192, kernel_size=1)
+        self.branch3x3_2 = BasicConv2d(192, 320, kernel_size=3, stride=2)
+
+        self.branch7x7x3_1 = BasicConv2d(in_channels, 192, kernel_size=1)
+        self.branch7x7x3_2 = BasicConv2d(192, 192, kernel_size=(1, 7), padding=(0, 3))
+        self.branch7x7x3_3 = BasicConv2d(192, 192, kernel_size=(7, 1), padding=(3, 0))
+        self.branch7x7x3_4 = BasicConv2d(192, 192, kernel_size=3, stride=2)
+
+    def forward(self, x):
+        branch3x3 = self.branch3x3_1(x)
+        branch3x3 = self.branch3x3_2(branch3x3)
+
+        branch7x7x3 = self.branch7x7x3_1(x)
+        branch7x7x3 = self.branch7x7x3_2(branch7x7x3)
+        branch7x7x3 = self.branch7x7x3_3(branch7x7x3)
+        branch7x7x3 = self.branch7x7x3_4(branch7x7x3)
+
+        branch_pool = F.max_pool2d(x, kernel_size=3, stride=2)
+        outputs = [branch3x3, branch7x7x3, branch_pool]
+        return torch.cat(outputs, 1)
+
+
+class InceptionE(nn.Module):
+
+    def __init__(self, in_channels):
+        super(InceptionE, self).__init__()
+        self.branch1x1 = BasicConv2d(in_channels, 320, kernel_size=1)
+
+        self.branch3x3_1 = BasicConv2d(in_channels, 384, kernel_size=1)
+        self.branch3x3_2a = BasicConv2d(384, 384, kernel_size=(1, 3), padding=(0, 1))
+        self.branch3x3_2b = BasicConv2d(384, 384, kernel_size=(3, 1), padding=(1, 0))
+
+        self.branch3x3dbl_1 = BasicConv2d(in_channels, 448, kernel_size=1)
+        self.branch3x3dbl_2 = BasicConv2d(448, 384, kernel_size=3, padding=1)
+        self.branch3x3dbl_3a = BasicConv2d(384, 384, kernel_size=(1, 3), padding=(0, 1))
+        self.branch3x3dbl_3b = BasicConv2d(384, 384, kernel_size=(3, 1), padding=(1, 0))
+
+        self.branch_pool = BasicConv2d(in_channels, 192, kernel_size=1)
+
+    def forward(self, x):
+        branch1x1 = self.branch1x1(x)
+
+        branch3x3 = self.branch3x3_1(x)
+        branch3x3 = [
+            self.branch3x3_2a(branch3x3),
+            self.branch3x3_2b(branch3x3),
+        ]
+        branch3x3 = torch.cat(branch3x3, 1)
+
+        branch3x3dbl = self.branch3x3dbl_1(x)
+        branch3x3dbl = self.branch3x3dbl_2(branch3x3dbl)
+        branch3x3dbl = [
+            self.branch3x3dbl_3a(branch3x3dbl),
+            self.branch3x3dbl_3b(branch3x3dbl),
+        ]
+        branch3x3dbl = torch.cat(branch3x3dbl, 1)
+
+        branch_pool = F.avg_pool2d(x, kernel_size=3, stride=1, padding=1)
+        branch_pool = self.branch_pool(branch_pool)
+
+        outputs = [branch1x1, branch3x3, branch3x3dbl, branch_pool]
+        return torch.cat(outputs, 1)
+
+
+class InceptionAux(nn.Module):
+
+    def __init__(self, in_channels, num_classes):
+        super(InceptionAux, self).__init__()
+        self.conv0 = BasicConv2d(in_channels, 128, kernel_size=1)
+        self.conv1 = BasicConv2d(128, 768, kernel_size=5)
+        self.conv1.stddev = 0.01
+        self.fc = nn.Linear(768, num_classes)
+        self.fc.stddev = 0.001
+
+    def forward(self, x):
+        # 17 x 17 x 768
+        x = F.avg_pool2d(x, kernel_size=5, stride=3)
+        # 5 x 5 x 768
+        x = self.conv0(x)
+        # 5 x 5 x 128
+        x = self.conv1(x)
+        # 1 x 1 x 768
+        x = x.view(x.size(0), -1)
+        # 768
+        x = self.fc(x)
+        # 1000
+        return x
+
+
+class BasicConv2d(nn.Module):
+
+    def __init__(self, in_channels, out_channels, **kwargs):
+        super(BasicConv2d, self).__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, bias=False, **kwargs)
+        self.bn = nn.BatchNorm2d(out_channels, eps=0.001)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        return F.relu(x, inplace=False)

--- a/test/model_defs/op_test.py
+++ b/test/model_defs/op_test.py
@@ -25,3 +25,12 @@ class ConcatNet(nn.Module):
 
     def forward(self, inputs):
         return torch.cat(inputs, 1)
+
+
+class CloneNet(nn.Module):
+
+    def __init__(self):
+        super(CloneNet, self).__init__()
+
+    def forward(self, x):
+        return x.clone()

--- a/test/model_defs/wrapper.py
+++ b/test/model_defs/wrapper.py
@@ -42,6 +42,7 @@ def torch_export(model, x, embed_params=False):
     # Enable tracing on the model
     ts1 = timeit.default_timer()
     trace, torch_out = torch.jit.record_trace(toC(model), toC(x))
+    # print(str(trace))
     ts2 = timeit.default_timer()
     print('\n[time] {} spent {:.2f} seconds.'.format('pytorch_execution', ts2 - ts1))
     if embed_params is False:
@@ -78,19 +79,26 @@ def caffe2_load(proto, model, x, state_dict=None, use_gpu=True, embed_params=Fal
     if embed_params is False:
         if state_dict:
             parameters = []
+            # params_keys = []
             # Passed in state_dict may have a different order.  Make
             # sure our order is consistent with the model's order.
             # TODO: Even better: keyword arguments!
             for k in model.state_dict():
                 parameters.append(state_dict[k])
+                # params_keys.append(k)
         else:
+            # params_keys = model.state_dict().keys()
             parameters = model.state_dict().values()
+        # idx = 0
         for k, v in zip(graph_def.input, itertools.chain(parameters, [x])):
             # On C2 side, we don't run on CUDA yet so convert to CPU memory
+            # print('state: {} graph: {}'.format(params_keys[idx], k))
             if isinstance(v, Variable):
                 W[k] = v.data.cpu().numpy()
             else:
                 W[k] = v.cpu().numpy()
+        # import pdb
+        # pdb.set_trace()
     else:
         W[graph_def.input[-1]] = x.data.cpu().numpy()
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -12,7 +12,7 @@ from model_defs.inception import Inception3
 from model_defs.squeezenet import SqueezeNet
 from model_defs.densenet import DenseNet
 from model_defs.dcgan import _netD, _netG, weights_init, bsz, imgsz, nz, ngf, ndf, nc
-from model_defs.op_test import DummyNet, ConcatNet
+from model_defs.op_test import DummyNet, ConcatNet, CloneNet
 
 import toffee
 import google.protobuf.text_format
@@ -52,6 +52,14 @@ class TestModels(TestCase):
         inputs = [toC(input_a), toC(input_b)]
         trace, _ = torch.jit.record_trace(toC(ConcatNet()), inputs)
         # print(str(trace))
+        self.assertExpected(str(trace))
+        self.assertToffeeExpected(torch._C._jit_pass_export(trace), "pbtxt")
+
+    def test_clone(self):
+        input_a = Variable(torch.randn(BATCH_SIZE, 3), requires_grad=True)
+        x = toC(input_a)
+        trace, _ = torch.jit.record_trace(toC(CloneNet()), x)
+        print(str(trace))
         self.assertExpected(str(trace))
         self.assertToffeeExpected(torch._C._jit_pass_export(trace), "pbtxt")
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -375,6 +375,11 @@ class Resize(Function):
 class Clone(Function):
 
     @staticmethod
+    def primspec(g, input):
+        print('defining primspec')
+        return g.appendNode(g.create("Copy", [input]))
+
+    @staticmethod
     def forward(ctx, input):
         return input.clone()
 


### PR DESCRIPTION
while e2e testing the non-pretrained model, we found that the existing weight init for Conv layers in Inception leads to non-matching output with caffe2. However, if we change the weight init to 
'm.weight.data.normal_(0.0, 0.02)' then it works fine and catch output with caffe2. This is a very weird behavior.

We also tried: 
weight init = constant fill 0, 1, 1e5 and they all work fine

@apaszke @soumith have you seen this behaviour before? To repro, cherry-pick this commit on hash 6747cbd and run 

python test/model_defs/caffe2_pytorch_test_models.py TestCaffe2BackendEmbed.test_inception