### PR TITLE
Convert ToffeeIR to SSA

### DIFF
--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -22,6 +22,7 @@ from squeezenet import SqueezeNet
 from densenet import DenseNet
 from super_resolution import SuperResolutionNet
 import dcgan
+import torch.nn as nn
 
 skip = unittest.skip
 
@@ -234,6 +235,10 @@ class TestCaffe2Backend(unittest.TestCase):
                 return input + c.type_as(input)
 
         self.run_model_test(MyModel(), train=False, batch_size=BATCH_SIZE)
+
+    def test_consumed_bn(self):
+        underlying = nn.BatchNorm2d(3)
+        self.run_model_test(underlying, train=True, batch_size=BATCH_SIZE)
 
 
 # add the same test suite as above, but switch embed_params=False

--- a/torch/csrc/autograd/functions/toffee/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/toffee/batch_normalization.cpp
@@ -12,28 +12,23 @@ jit::node_list BatchNormForward::primspec(PrimSpecContext* ctx, jit::node_list i
   auto bn = g->appendNode(g->create(jit::kSpatialBN,{inputs.at(0),inputs.at(1),inputs.at(2)}));
   bn->addInput(jit::tracer::getBufferTrace(*ctx->buffer_map, cached_running_mean));
   bn->addInput(jit::tracer::getBufferTrace(*ctx->buffer_map, cached_running_var));
-
   bn->i_(jit::kis_test, !this->training);
   bn->f_(jit::kepsilon, eps);
   bn->s_(jit::korder, "NCHW");
   bn->f_(jit::kmomentum, 1 - momentum);
 
-  std::vector<int64_t> inplace_outputs;
   auto orig_output = g->appendNode(g->createSelect(bn, 0));
-  inplace_outputs.push_back(-1);
 
   if(this->training) {
     g->appendNode(g->createSelect(bn, 1)->setType(bn->inputs().at(3)->type()));
-    inplace_outputs.push_back(3);
     g->appendNode(g->createSelect(bn, 2)->setType(bn->inputs().at(4)->type()));
-    inplace_outputs.push_back(4);
     // dummy output
     for(int i = 3; i < 5; i++) {
       g->appendNode(g->createSelect(bn, i)->setDebugName("batch_norm_dead_output"));
-      inplace_outputs.push_back(-1);
     }
   }
-  bn->is_(jit::kInPlaceOutputs,std::move(inplace_outputs));
+  bn->is_(jit::kconsumed_inputs,{0,0,0,1,1});
+
   ctx->batch_norm_count++;
   return {orig_output};
 }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -36,7 +36,7 @@ _(is_test) \
 _(epsilon) \
 _(order) \
 _(momentum) \
-_(InPlaceOutputs) \
+_(consumed_inputs) \
 _(kernels) \
 _(kernel) \
 _(strides) \

--- a/torch/csrc/toffee/export.cpp
+++ b/torch/csrc/toffee/export.cpp
@@ -270,30 +270,11 @@ static void encodeGraph(toffee::GraphProto * p_g, std::shared_ptr<Graph> & g, co
     for(auto input : node->inputs()) {
       p_n->add_input(node_name(input));
     }
-    // jit::Node and toffee protobuf don't agree on how to represent
-    // so called 'inplace' operators that mutate inputs
-    // 'InPlaceOutputs' has an entry for each output of this node
-    // if the entry is >= 0, it specifies the index of the input
-    // which is mutated and returned as an output
-    // we use that to translate to ToffeeIR's replicated naming scheme
-    // where inputs/outputs will have the same name
-    std::vector<int64_t> * inplace_outputs = nullptr;
-    if(node->hasAttribute(jit::kInPlaceOutputs))
-      inplace_outputs = &node->is(jit::kInPlaceOutputs);
-    int i = 0;
     for(auto output : node->outputs()) {
-      if(!inplace_outputs || inplace_outputs->at(i) < 0) {
-        p_n->add_output(node_name(output));
-      } else {
-        Node * input = node->inputs().at(inplace_outputs->at(i));
-        p_n->add_output(node_name(input));
-      }
-      i++;
+      p_n->add_output(node_name(output));
     }
     p_n->set_op_type(symbolToString(node->kind()));
     for(auto attr_name : node->attributeNames()) {
-      if(attr_name == kInPlaceOutputs)
-        continue;
       addAttribute(p_n, node, attr_name);
     }
   }


### PR DESCRIPTION
'consumed_inputs' marks places where a node destructively consumes its input. 

Do not merge until https://github.com/ProjectToffee/ToffeeIR/pull/68 is reviewed and landed.