### PR TITLE
Use plural attributes in MaxPool1d, MaxPool2d and AvgPool2d

### DIFF
--- a/test/model_defs/caffe2_pytorch_test_models.py
+++ b/test/model_defs/caffe2_pytorch_test_models.py
@@ -51,6 +51,7 @@ model_urls = {
 
 class TestCaffe2Backend(unittest.TestCase):
     embed_params = False
+
     def run_model_test(self, model, train, batch_size, state_dict=None,
                        input=None):
         torch.manual_seed(0)

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -16,10 +16,10 @@ class MaxPool1d(Function):
             return None
         stride = stride or kernel_size
         n = g.appendNode(g.create("MaxPool", [input])
-                          .i_("kernel", kernel_size)
-                          .i_("pad", padding)
-                          .i_("dilation", dilation)
-                          .i_("stride", stride))
+                          .is_("kernels", [kernel_size])
+                          .is_("pads", [padding] * 2)
+                          .is_("dilations", [dilation])
+                          .is_("strides", [stride]))
         return (n, None)
 
     @staticmethod
@@ -100,10 +100,10 @@ class MaxPool2d(Function):
         if ceil_mode:
             return None
         n = g.appendNode(g.create("MaxPool", [input])
-                          .i_("kernel", kernel_size)
-                          .i_("pad", padding)
-                          .i_("dilation", dilation)
-                          .i_("stride", stride))
+                          .is_("kernels", [kernel_size] * 2)
+                          .is_("pads", [padding] * 4)
+                          .is_("dilations", [dilation] * 2)
+                          .is_("strides", [stride] * 2))
         return (n, None)
 
     @staticmethod
@@ -372,9 +372,9 @@ class AvgPool2d(Function):
             return None
         stride = stride or kernel_size
         n = g.appendNode(g.create("AveragePool", [input])
-                          .i_("kernel", kernel_size)
-                          .i_("stride", stride)
-                          .i_("pad", padding))
+                          .is_("kernels", [kernel_size] * 2)
+                          .is_("strides", [stride] * 2)
+                          .is_("pads", [padding] * 4))
         return (n, None)
 
     @staticmethod


### PR DESCRIPTION
In MaxPool1d/MaxPool2d/AvgPool2d, we should use plural format instead of singular in primspec.