### PR TITLE
Use https gitmodule for ToffeeIR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/nanopb/nanopb.git
 [submodule "torch/lib/ToffeeIR"]
 	path = torch/lib/ToffeeIR
-	url = git@github.com:ProjectToffee/ToffeeIR.git
+	url = https://github.com/ProjectToffee/ToffeeIR.git


### PR DESCRIPTION
We need this for CI, because pytorchbot doesn't have any SSH
keys and I am too lazy to set it up.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>