### PR TITLE
Support calling traced functions multiple times in forward + dispatch to different traces based on input flags/objects

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -255,9 +255,9 @@ class TestAutograd(TestCase):
     def test_grad_badcalls(self):
         x = Variable(torch.ones(1))
         y = x ** 2
-        with self.assertRaisesRegex(RuntimeError, 'unreachable'):
+        with self.assertRaisesRegex(RuntimeError, 'does not require grad'):
             torch.autograd.grad(x, y)
-        with self.assertRaisesRegex(RuntimeError, 'no graph nodes that require computing gradients'):
+        with self.assertRaisesRegex(RuntimeError, 'does not require grad'):
             torch.autograd.grad(y, x)
 
         x = Variable(torch.ones(1), requires_grad=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -324,6 +324,11 @@ class TestJit(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'different flags'):
             fn(x).backward(Variable(torch.ones(1), requires_grad=True))
         # TODO: enable once AutogradClosure registers prev stage inputs correctly
+        # The problem is that the tracer sometimes catches unnecessary operations.
+        # For example, some ops will still return a valid grad, even though their
+        # next_function doesn't need it, and if two ops do it, they will get summed
+        # together - the Add function will have two inputs that don't require grad,
+        # and this causees some problems in jit_closure.cpp
         # grad_x, = torch.autograd.grad(fn(x), (x,), create_graph=True)
         # grad_x.backward()
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -40,7 +40,7 @@ class TestModels(TestCase):
 
     def test_ops(self):
         x = Variable(
-            torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0), requires_grad=True
+            torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0), volatile=True
         )
         trace, _ = torch.jit.record_trace(toC(DummyNet()), toC(x))
         self.assertExpected(str(trace))
@@ -48,29 +48,29 @@ class TestModels(TestCase):
 
     def test_prelu(self):
         x = Variable(
-            torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0), requires_grad=True
+            torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0), volatile=True
         )
         trace, _ = torch.jit.record_trace(PReluNet(), x)
         self.assertExpected(str(trace))
         self.assertONNXExpected(trace.export(False), "pbtxt")
 
     def test_concat(self):
-        input_a = Variable(torch.randn(BATCH_SIZE, 3), requires_grad=True)
-        input_b = Variable(torch.randn(BATCH_SIZE, 3), requires_grad=True)
+        input_a = Variable(torch.randn(BATCH_SIZE, 3), volatile=True)
+        input_b = Variable(torch.randn(BATCH_SIZE, 3), volatile=True)
         inputs = [toC(input_a), toC(input_b)]
         trace, _ = torch.jit.record_trace(toC(ConcatNet()), inputs)
         self.assertExpected(str(trace))
         self.assertONNXExpected(trace.export(False), "pbtxt")
 
     def test_permute(self):
-        x = Variable(torch.randn(BATCH_SIZE, 3, 10, 12), requires_grad=True)
+        x = Variable(torch.randn(BATCH_SIZE, 3, 10, 12), volatile=True)
         trace, _ = torch.jit.record_trace(PermuteNet(), x)
         self.assertExpected(str(trace))
         self.assertONNXExpected(trace.export(False), "pbtxt")
 
     def test_srresnet(self):
         x = Variable(torch.randn(1, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         trace, _ = torch.jit.record_trace(
             toC(SRResNet(rescale_factor=4, n_filters=64, n_blocks=8)), toC(x))
         self.assertExpected(str(trace))
@@ -79,7 +79,7 @@ class TestModels(TestCase):
     @skipIfNoLapack
     def test_super_resolution(self):
         x = Variable(
-            torch.randn(BATCH_SIZE, 1, 224, 224).fill_(1.0), requires_grad=True
+            torch.randn(BATCH_SIZE, 1, 224, 224).fill_(1.0), volatile=True
         )
         trace, _ = torch.jit.record_trace(
             toC(SuperResolutionNet(upscale_factor=3)), toC(x))
@@ -88,7 +88,7 @@ class TestModels(TestCase):
 
     def test_alexnet(self):
         x = Variable(
-            torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0), requires_grad=True
+            torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0), volatile=True
         )
         trace, _ = torch.jit.record_trace(toC(AlexNet()), toC(x))
         self.assertExpected(str(trace))
@@ -96,7 +96,7 @@ class TestModels(TestCase):
 
     def test_mnist(self):
         x = Variable(torch.randn(BATCH_SIZE, 1, 28, 28).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         trace, _ = torch.jit.record_trace(toC(MNIST()), toC(x))
         self.assertExpected(str(trace))
         # FeatureDropout primspec is not implemented yet
@@ -105,7 +105,7 @@ class TestModels(TestCase):
     def test_vgg(self):
         # VGG 16-layer model (configuration "D")
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         vgg16 = make_vgg16()
         trace, _ = torch.jit.record_trace(toC(vgg16), toC(x))
         self.assertExpected(str(trace), "16")
@@ -113,7 +113,7 @@ class TestModels(TestCase):
 
         # VGG 16-layer model (configuration "D") with batch normalization
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         vgg16_bn = make_vgg16_bn()
         trace, _ = torch.jit.record_trace(toC(vgg16_bn), toC(x))
         self.assertExpected(str(trace), "16_bn")
@@ -121,7 +121,7 @@ class TestModels(TestCase):
 
         # VGG 19-layer model (configuration "E")
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         vgg19 = make_vgg19()
         trace, _ = torch.jit.record_trace(toC(vgg19), toC(x))
         self.assertExpected(str(trace), "19")
@@ -129,7 +129,7 @@ class TestModels(TestCase):
 
         # VGG 19-layer model (configuration 'E') with batch normalization
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         vgg19_bn = make_vgg19_bn()
         trace, _ = torch.jit.record_trace(toC(vgg19_bn), toC(x))
         self.assertExpected(str(trace), "19_bn")
@@ -138,7 +138,7 @@ class TestModels(TestCase):
     def test_resnet(self):
         # ResNet50 model
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         resnet50 = ResNet(Bottleneck, [3, 4, 6, 3])
         trace, _ = torch.jit.record_trace(toC(resnet50), toC(x))
         self.assertExpected(str(trace), "50")
@@ -146,7 +146,7 @@ class TestModels(TestCase):
 
     def test_inception(self):
         x = Variable(
-            torch.randn(BATCH_SIZE, 3, 299, 299).fill_(1.0), requires_grad=True)
+            torch.randn(BATCH_SIZE, 3, 299, 299).fill_(1.0), volatile=True)
         trace, _ = torch.jit.record_trace(toC(Inception3()), toC(x))
         self.assertExpected(str(trace), "3")
         self.assertONNXExpected(trace.export(False), "3-pbtxt")
@@ -155,7 +155,7 @@ class TestModels(TestCase):
         # SqueezeNet: AlexNet-level accuracy with 50x fewer parameters and
         # <0.5MB model size
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         sqnet_v1_0 = SqueezeNet(version=1.1)
         trace, _ = torch.jit.record_trace(toC(sqnet_v1_0), toC(x))
         self.assertExpected(str(trace), "1_0")
@@ -164,7 +164,7 @@ class TestModels(TestCase):
         # SqueezeNet 1.1 has 2.4x less computation and slightly fewer params
         # than SqueezeNet 1.0, without sacrificing accuracy.
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         sqnet_v1_1 = SqueezeNet(version=1.1)
         trace, _ = torch.jit.record_trace(toC(sqnet_v1_1), toC(x))
         self.assertExpected(str(trace), "1_1")
@@ -173,7 +173,7 @@ class TestModels(TestCase):
     def test_densenet(self):
         # Densenet-121 model
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0),
-                     requires_grad=True)
+                     volatile=True)
         dense121 = DenseNet(num_init_features=64, growth_rate=32,
                             block_config=(6, 12, 24, 16))
         trace, _ = torch.jit.record_trace(toC(dense121), toC(x))
@@ -226,7 +226,7 @@ class TestModels(TestCase):
                          nhid, nlayers, dropout,
                          tied, batchsize)
         x = Variable(torch.LongTensor(10, batchsize).fill_(1),
-                     requires_grad=False)
+                     volatile=False)
         trace, _ = torch.jit.record_trace(model, x)
         self.assertExpected(str(trace))
         # self.assertONNXExpected(trace.export(False), "pbtxt")

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -57,8 +57,8 @@ class TestModels(TestCase):
     def test_concat(self):
         input_a = Variable(torch.randn(BATCH_SIZE, 3), volatile=True)
         input_b = Variable(torch.randn(BATCH_SIZE, 3), volatile=True)
-        inputs = [toC(input_a), toC(input_b)]
-        trace, _ = torch.jit.record_trace(toC(ConcatNet()), inputs)
+        inputs = (toC(input_a), toC(input_b))
+        trace, _ = torch.jit.record_trace(toC(ConcatNet()), inputs, num_derivatives=0)
         self.assertExpected(str(trace))
         self.assertONNXExpected(trace.export(False), "pbtxt")
 

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -35,7 +35,7 @@ class TestONNX(TestCase):
         x = Variable(torch.Tensor([0.4]), requires_grad=True)
         y = Variable(torch.Tensor([0.7]), requires_grad=True)
 
-        trace = torch._C._tracer_enter((x, y))
+        trace = torch._C._tracer_enter((x, y), 0)
         z = -torch.sigmoid(torch.tanh(x * (x + y)))
         torch._C._tracer_exit((z,))
         torch._C._jit_pass_lint(trace)

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -16,12 +16,6 @@
 #include <memory>
 #include <vector>
 
-namespace torch { namespace jit { namespace tracer {
-
-struct FunctionTracingState;
-
-}}}
-
 namespace torch { namespace autograd {
 
 struct Function;

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -324,8 +324,7 @@ void initAutogradClosureBindings(PyObject* module) {
     ;
 
   m.def("_jit_createAutogradClosure", [](jit::tracer::TracingState* tracing_state) {
-    auto & graph = tracing_state->graph;
-    return std::make_shared<AutogradClosureFactory>(graph.get());
+    return std::make_shared<AutogradClosureFactory>(tracing_state);
   });
 }
 

--- a/torch/csrc/autograd/functions/jit_closure.h
+++ b/torch/csrc/autograd/functions/jit_closure.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/tracer_state.h"
 #include "torch/csrc/autograd/engine.h"
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
@@ -14,7 +15,7 @@ namespace torch { namespace autograd {
 struct MultiStageClosure;
 
 struct AutogradClosureFactory {
-  AutogradClosureFactory(torch::jit::Graph *graph);
+  AutogradClosureFactory(torch::jit::tracer::TracingState *graph);
 
   std::shared_ptr<Function> construct();
 

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -130,11 +130,14 @@ auto Eval::computeInputOrder(const variable_list& inputs, const placeholder_list
   return input_order;
 }
 
-void Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _outputs,
+bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _outputs,
                            const placeholder_list& inherited_placeholders) {
   // _outputs has a prefix deliberately, because it's unlikely that anything else
   // than relevant_outputs will be needed inside this function.
   variable_list relevant_outputs = filterRelevantOutputs(inputs, _outputs);
+
+  if (relevant_outputs.size() == 0)
+    return false;
 
   for (auto & output : relevant_outputs)
     roots.emplace_back(output->grad_fn, output->output_nr);
@@ -180,6 +183,8 @@ void Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
     output->grad_fn = shared_from_this();
     output->output_nr = num_inputs++;
   }
+
+  return true;
 }
 
 variable_list Eval::apply(const variable_list& inputs) {

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -188,7 +188,7 @@ variable_list Eval::apply(const variable_list& inputs) {
   auto& engine = python::PythonEngine::getDefaultEngine();
   engine.execute(roots, inputs, true, getCallbacks(outputs, outputs_mutex));
 
-  auto bw_eval = std::make_shared<Eval>();
+  auto bw_eval = newEval();
   bw_eval->replaceSubgraph(inputs, outputs, placeholders);
 
   // This will prevent Function::traced_apply from marking the backward subgraph as non-traceable.

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -59,7 +59,7 @@ struct Eval : Function {
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  void replaceSubgraph(
+  bool replaceSubgraph(
       const variable_list& inputs,
       const variable_list& outputs,
       const placeholder_list& inherited_placeholders = placeholder_list());

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -53,6 +53,8 @@ struct Eval : Function {
     Boundary boundary;
   };
 
+  virtual ~Eval() {}
+
   virtual inline bool is_traceable() final { return traceable; }
 
   virtual variable_list apply(const variable_list& inputs) override;
@@ -70,6 +72,10 @@ struct Eval : Function {
     if (relevant_outputs.size() == 0)
       return nullptr;
     return std::dynamic_pointer_cast<Eval>(relevant_outputs[0]->grad_fn);
+  }
+
+  virtual std::shared_ptr<Eval> newEval() {
+    return std::make_shared<Eval>();
   }
 
   function_list roots;

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -116,6 +116,10 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
   return py_functions.release();
 }
 
+PyObject* THPCppFunction_requires_grad(THPCppFunction* self) {
+  return PyBool_FromLong(self->cdata->is_executable);
+}
+
 PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var)
 {
   if (!THPVariable_Check(_var)) {

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -35,9 +35,11 @@ PyObject* CppFunction_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   {(char*)"register_hook", (PyCFunction)THPCppFunction_register_hook, METH_O, NULL}
 
 #define THP_FUNCTION_DEFAULT_PROPERTIES \
-  {(char*)"next_functions", (getter)THPCppFunction_next_functions, NULL, NULL, NULL}
+  {(char*)"next_functions", (getter)THPCppFunction_next_functions, NULL, NULL, NULL}, \
+  {(char*)"requires_grad", (getter)THPCppFunction_requires_grad, NULL, NULL, NULL}
 
 PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook);
+PyObject* THPCppFunction_requires_grad(THPCppFunction* self);
 PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var);
 PyObject* THPCppFunction_register_hook(PyObject* self, PyObject* hook);
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -188,6 +188,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     THPUtils_assert(PyTuple_Check(inputs), "inputs argument has to be a tuple");
     int num_inputs = PyTuple_GET_SIZE(inputs);
     ctx.outputs = PyTuple_New(num_inputs);
+    if (!ctx.outputs) return NULL;
     // First, find all relevant functions and fill ctx.output_map
     for (int i = 0; i < num_inputs; ++i) {
       PyObject *input = PyTuple_GET_ITEM(inputs, i);
@@ -202,6 +203,8 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
       }
       THPUtils_assert(grad_fn, "One of the differentiated Variables appears to not have "
           "been used in the graph");
+      THPUtils_assert(grad_fn->is_executable, "One of the differentiated Variables does "
+          "not require grad");
       auto& fn_info = ctx.output_map[grad_fn];
       fn_info.first.emplace_back(output_nr, i);
       fn_info.second = is_leaf;

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -91,7 +91,8 @@ auto SavedVariable::unpack(std::shared_ptr<Function> saved_for) -> std::shared_p
   if (requires_grad && !new_var->grad_fn && grad_accumulator.expired())
     throw std::logic_error("No grad accumulator for a saved leaf!");
   new_var->grad_accumulator = grad_accumulator;
-  new_var->tracing_state = tracing_state;
+  if (tracing_state)
+    new_var->tracing_state.reset(new jit::tracer::ValueTracingState(*tracing_state));
 
   return new_var;
 }

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -7,22 +7,50 @@
 
 namespace torch { namespace jit { namespace tracer {
 
-void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_list& outputs) {
-  std::make_shared<autograd::Eval>()->replaceSubgraph(inputs, outputs);
-}
+namespace {
 
-namespace detail {
+struct TraceEval : autograd::Eval {
+  TraceEval(const std::shared_ptr<TracingState>& tracing_state)
+    : weak_tracing_state(tracing_state) {
+    flag.clear();
+    tracing_state->eval_count++;
+    this->traceable = true;
+  }
+
+  virtual ~TraceEval() {
+    auto state = weak_tracing_state.lock();
+    if (--state->eval_count == 0 && state->graph->stage() != state->num_stages - 1) {
+      state->graph = nullptr;
+    }
+  }
+
+  virtual std::shared_ptr<Eval> newEval() override {
+    if (auto state = weak_tracing_state.lock()) {
+      return std::make_shared<TraceEval>(state);
+    } else {
+      return std::make_shared<autograd::Eval>();
+    }
+  }
+
+  std::weak_ptr<TracingState> weak_tracing_state;
+};
 
 struct TraceEnterHook : autograd::FunctionPreHook {
   TraceEnterHook(const std::shared_ptr<TracingState>& tracing_state)
-    : tracing_state(tracing_state) {}
+    : weak_tracing_state(tracing_state) {}
 
   virtual variable_list operator()(const variable_list& inputs) {
+    // TODO: this shouldn't be run only once - it might be possible that this stage is
+    // called multiple times, but e.g. only the second call is unrolled for as many
+    // stages as we want.
     std::call_once(flag, &TraceEnterHook::enterTrace, this, std::ref(inputs));
     return inputs;
   }
 
   void enterTrace(const variable_list& inputs) {
+    auto tracing_state = weak_tracing_state.lock();
+    if (!tracing_state) return;
+
     auto& graph = tracing_state->graph;
     tracing_state->active = true;
     graph->advanceStage();
@@ -35,13 +63,13 @@ struct TraceEnterHook : autograd::FunctionPreHook {
     }
   }
 
-  std::shared_ptr<TracingState> tracing_state;
+  std::weak_ptr<TracingState> weak_tracing_state;
   std::once_flag flag;
 };
 
 struct TraceExitHook : autograd::FunctionPostHook {
   TraceExitHook(const std::shared_ptr<TracingState>& tracing_state)
-    : tracing_state(tracing_state) {}
+    : weak_tracing_state(tracing_state) {}
 
   virtual variable_list operator()(const variable_list& outputs, const variable_list& inputs) {
     std::call_once(flag, &TraceExitHook::exitTrace, this, std::ref(inputs), std::ref(outputs));
@@ -49,27 +77,37 @@ struct TraceExitHook : autograd::FunctionPostHook {
   }
 
   void exitTrace(const variable_list& inputs, const variable_list& outputs) {
+    auto tracing_state = weak_tracing_state.lock();
+    if (!tracing_state) return;
+
     detail::_exit(tracing_state, outputs);
     // Unfortunately there's no easy way to get handle of the backward node for current Eval.
     auto eval_fn = autograd::Eval::getBackwardEval(inputs, outputs);
     if (!eval_fn) return;
     eval_fn->pre_hooks.emplace_back(std::make_shared<TraceEnterHook>(tracing_state));
     eval_fn->post_hooks.emplace_back(std::make_shared<TraceExitHook>(tracing_state));
-    eval_fn->traceable = true;
   }
 
-  std::shared_ptr<TracingState> tracing_state;
+  std::weak_ptr<TracingState> weak_tracing_state;
   std::once_flag flag;
 };
 
+} // anonymous namespace
+
+namespace detail {
+
 void traceBackward(const std::shared_ptr<TracingState>& tracing_state, const variable_list& inputs, const variable_list& outputs) {
-  auto eval_fn = std::make_shared<autograd::Eval>();
+  // TODO: add note on how we depend on TracedEval being created in here
+  auto eval_fn = std::make_shared<TraceEval>(tracing_state);
   eval_fn->replaceSubgraph(inputs, outputs);
-  eval_fn->traceable = true;
   eval_fn->pre_hooks.emplace_back(std::make_shared<TraceEnterHook>(tracing_state));
   eval_fn->post_hooks.emplace_back(std::make_shared<TraceExitHook>(tracing_state));
 }
 
 } // namespace detail
+
+void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_list& outputs) {
+  std::make_shared<autograd::Eval>()->replaceSubgraph(inputs, outputs);
+}
 
 }}}

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -62,6 +62,7 @@ struct TraceEnterHook : autograd::FunctionPreHook {
       setValueTrace(tracing_state, input, input_node);
       input_node->inferTypeFrom(input->data);
     }
+    tracing_state->var_flags[graph->stage()] = detail::getVarFlags(inputs);
   }
 
   std::weak_ptr<TracingState> weak_tracing_state;

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -51,10 +51,8 @@ inline bool isElemActive(const ValueTracingStateElem& vts) {
   return state && state->active;
 }
 
-inline std::vector<std::pair<bool, bool>> getVarFlags(const variable_list& vars) {
-  return fmap(vars, [](const std::shared_ptr<Variable>& var) {
-    return std::make_pair(var->requires_grad, var->is_volatile);
-  });
+inline std::vector<VariableFlags> getVarFlags(const variable_list& vars) {
+  return fmap(vars, &VariableFlags::create);
 }
 
 }

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -35,7 +35,8 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
     : graph(new Graph())
     , active(false)
     , num_stages(num_stages)
-    , eval_count(0) {}
+    , eval_count(0)
+    , var_flags(num_stages) {}
 
   // XXX: graph can be NULL if it's a failed trace (failed = didn't capture all
   // the stages we care about)
@@ -50,6 +51,7 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   // TODO: Perhaps, turn this into an owning reference.  The buffers
   // are persistent, so this won't lead to a leak.
   std::unordered_map<void*, Node*> buffer_map;
+  std::vector<std::vector<std::pair<bool, bool>>> var_flags;
 
   std::mutex mutex;
   variable_list inputs; // Used only for the duration of first stage

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/assert.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+#include <cstdint>
+#include <list>
+
+namespace torch { namespace autograd {
+
+struct Variable;
+
+}}
+
+namespace torch { namespace jit { namespace tracer {
+
+using torch::autograd::Variable;
+using variable_list = std::vector<std::shared_ptr<Variable>>;
+
+// TracingState tracks the necessary state when we are tracing the execution of
+// autograd code; most importantly, it holds a reference to the actual IR
+// graph which we are recording the trace to.
+//
+// The liveness of a TracingState is expected to be a superset of the region
+// of code being traced; in particular, Variables do not keep a TracingState
+// live.  Instead, they hold weak pointers to TracingState, to prevent leaks
+// from arising when a variable that participated in a trace outlives the
+// actual trace itself.
+
+struct TracingState : public std::enable_shared_from_this<TracingState> {
+  TracingState(std::size_t num_stages)
+    : graph(new Graph())
+    , active(false)
+    , num_stages(num_stages)
+    , eval_count(0) {}
+
+  // XXX: graph can be NULL if it's a failed trace (failed = didn't capture all
+  // the stages we care about)
+  std::shared_ptr<Graph> graph;
+  bool active;
+
+  // Used to free the Graph as soon as we know this trace will fail
+  std::size_t num_stages;
+  std::atomic<std::size_t> eval_count;
+
+  // void* is an unsafe TH.  NON-OWNING, so it might get invalidated.
+  // TODO: Perhaps, turn this into an owning reference.  The buffers
+  // are persistent, so this won't lead to a leak.
+  std::unordered_map<void*, Node*> buffer_map;
+
+  std::mutex mutex;
+  variable_list inputs; // Used only for the duration of first stage
+
+  std::unique_lock<std::mutex> lock() { return std::unique_lock<std::mutex>(mutex); };
+
+  bool is_expired() const {
+    return !graph;
+  }
+
+  bool is_complete() const {
+    return !is_expired() && graph->stage() == num_stages - 1;
+  }
+};
+
+struct ValueTracingStateElem {
+  std::weak_ptr<TracingState> state;
+  // it's only valid to use this field if !state.exired()
+  Node* trace = nullptr;
+
+  void reset() {
+    state.reset();
+    trace = nullptr;
+  }
+};
+
+using ValueTracingState = std::list<ValueTracingStateElem>;
+
+struct FunctionTracingState {
+  bool in_eval_subgraph = false;
+};
+
+}}}

--- a/torch/csrc/utils/functional.h
+++ b/torch/csrc/utils/functional.h
@@ -13,4 +13,16 @@ static std::vector<R> fmap(const std::vector<T> & inputs, const F& fn) {
   return r;
 }
 
+template<typename F, typename T>
+static std::vector<T> filter(const std::vector<T> & inputs, const F& fn) {
+  std::vector<T> r;
+  r.reserve(inputs.size());
+  for(auto & input : inputs) {
+    if (fn(input)) {
+      r.push_back(input);
+    }
+  }
+  return r;
+}
+
 }

--- a/torch/jit.py
+++ b/torch/jit.py
@@ -2,6 +2,7 @@ import torch.autograd.function as function
 import torch._C
 from torch.autograd import Variable
 from torch.nn import Module
+from collections import defaultdict
 import itertools
 import types
 import contextlib
@@ -92,8 +93,50 @@ def _verify(flat_trace_out, flat_real_out):
 class Traceable(object):
     _next_trace_id = 0
     _dump_traces = os.environ.get('PYTORCH_JIT_DUMP', False)
+    VOLATILE = object()
 
-    def __init__(self, function_or_module, num_derivatives=1, parameters=None, trace_name=None, optimize=False, verify=False, time=False, enabled=True):
+    # Traceable holds multiple traces and switches between them based on
+    # inputs provided to a call. Things that need to be considered include
+    # non-Variable argument (e.g. num_layers=3; compared by equality) or
+    # Variable flags and sizes. TraceInfo is the object that is used to
+    # hold a trace for a single input configuration aka input_key.
+    class TraceInfo(object):
+        def __init__(self, trace_name):
+            self.traces = []
+            self.complete_trace = None
+            self.closure = None
+            self.trace_name = trace_name
+
+        def _run_pass(self, p):
+            name = p.__doc__
+            if Traceable._dump_traces:
+                with open("{}_{}_input.ir".format(self.trace_name, name), "w") as f:
+                    f.write(str(self.complete_trace))
+            p(self.complete_trace)
+            # TODO: Make linting optional
+            torch._C._jit_pass_lint(self.complete_trace)
+            if Traceable._dump_traces:
+                with open("{}_{}_output.ir".format(self.trace_name, name), "w") as f:
+                    f.write(str(self.complete_trace))
+
+        def compile_trace(self, optimize):
+            if optimize:
+                self._run_pass(torch._C._jit_pass_init)
+                self._run_pass(torch._C._jit_pass_fuse)
+
+            # It's important to always run DCE, because backward can create a lot of unnecessary nodes
+            self._run_pass(torch._C._jit_pass_dce)
+            self.closure = torch._C._jit_createAutogradClosure(self.complete_trace)
+
+        def check_traces(self):
+            self.traces = [t for t in self.traces if not t.is_expired]
+            for trace in self.traces:
+                if trace.is_complete:
+                    self.complete_trace = trace
+                    self.traces = []
+
+    def __init__(self, function_or_module, num_derivatives=1, parameters=None, trace_name=None,
+                 optimize=False, verify=False, time=False, enabled=True):
         """
         time - collect cuda timing stats for perf debugging
         verify - run the original code, and check it is within threshold
@@ -110,8 +153,6 @@ class Traceable(object):
             self._state_values = lambda: param_list
 
         self.trace_name = trace_name
-        self.saved_trace = None
-        self.saved_closure = None
         self.optimize = optimize
         self.verify = verify
         self.time = time
@@ -119,35 +160,21 @@ class Traceable(object):
         self.proto = None
         self.traces = []
         self.num_derivatives = num_derivatives
+        self.traces = defaultdict(lambda: Traceable.TraceInfo(trace_name))
         if self.trace_name is None:
             self.trace_name = "trace_{}".format(Traceable._next_trace_id)
             Traceable._next_trace_id += 1
 
-    def _run_pass(self, name, p):
-        if Traceable._dump_traces:
-            with open("{}_{}_input.ir".format(self.trace_name, name), "w") as f:
-                f.write(str(self.saved_trace))
-        p(self.saved_trace)
-        # TODO: Make linting optional
-        torch._C._jit_pass_lint(self.saved_trace)
-        if Traceable._dump_traces:
-            with open("{}_{}_output.ir".format(self.trace_name, name), "w") as f:
-                f.write(str(self.saved_trace))
-
-    def compile_trace(self):
-        if self.optimize:
-            self._run_pass("init", torch._C._jit_pass_init)
-            self._run_pass("fuse", torch._C._jit_pass_fuse)
-
-        # It's important to always run DCE, because backward can create a lot of unnecessary nodes
-        self._run_pass('dce', torch._C._jit_pass_dce)
-        self.saved_closure = torch._C._jit_createAutogradClosure(
-            self.saved_trace)
+    def get_input_key(self, args):
+        if any(arg.volatile if isinstance(arg, Variable) else False for arg in args):
+            return self.VOLATILE
+        return tuple(arg.requires_grad if isinstance(arg, Variable) else arg
+                     for arg in args)
 
     def get_trace_inputs(self, args, extra=()):
         return tuple(itertools.chain(self._state_values(), flatten(args), extra))
 
-    def run_trace(self, args):
+    def run_closure(self, closure, args):
         if self.verify:
             cloned_args = tuple(_clone_inputs(args))
             with _time("run_real", self.time), _fork_rng(self.verify):
@@ -155,7 +182,7 @@ class Traceable(object):
 
         trace_inputs = self.get_trace_inputs(args)
         with _time("run_trace", self.time):
-            flat_out = self.saved_closure()(*_varify(trace_inputs))
+            flat_out = closure()(*_varify(trace_inputs))
         if not isinstance(flat_out, tuple):
             flat_out = (flat_out,)
 
@@ -164,23 +191,21 @@ class Traceable(object):
 
         return function._unflatten(flat_out, self.proto)
 
-    def check_traces(self):
-        for trace in self.traces:
-            if trace.is_complete:
-                self.saved_trace = trace
-                self.traces = []
-        self.traces = [t for t in self.traces if not t.is_expired]
-
-    # create and return a trace, possibly verifying it before returning it
-    def record_trace(self, args, extra=()):
+    def record_trace(self, args, is_volatile=False, extra=()):
         trace_inputs = self.get_trace_inputs(args, extra)
 
-        trace = torch._C._tracer_enter(trace_inputs, self.num_derivatives)
+        trace = torch._C._tracer_enter(trace_inputs, 0 if is_volatile else self.num_derivatives)
         out = self._run(*args)
         torch._C._tracer_exit(flatten(out))
-        self.traces.append(trace)
 
-        return out
+        return trace, out
+
+    def has_trace_for(self, *args):
+        trace_info = self.traces.get(self.get_input_key(args))
+        if trace_info is None:
+            return False
+        trace_info.check_traces()
+        return trace_info.complete_trace is not None
 
     def __call__(self, *args):
         # Run the real thing if tracing is disabled
@@ -188,19 +213,22 @@ class Traceable(object):
             with _time("run_real", self.time):
                 return self._run(*args)
 
+        input_key = self.get_input_key(args)
+        trace_info = self.traces[input_key]
         # Use the compiled closure if we have it already
-        if self.saved_closure is not None:
-            return self.run_trace(args)
+        if trace_info.closure is not None:
+            return self.run_closure(trace_info.closure, args)
 
         # Check if any of the traces in our pool are complete now
-        self.check_traces()
-        if self.saved_trace is not None:
-            self.compile_trace()
-            return self.run_trace(args)
+        trace_info.check_traces()
+        if trace_info.complete_trace is not None:
+            trace_info.compile_trace(self.optimize)
+            return self.run_closure(trace_info.closure, args)
 
         # Otherwise, we have to collect a new trace
-        return self.record_trace(args)
-
+        trace, out = self.record_trace(args, input_key == self.VOLATILE)
+        trace_info.traces.append(trace)
+        return out
 
 
 def record_trace(traceable, *args, **kwargs):
@@ -213,9 +241,7 @@ def record_trace(traceable, *args, **kwargs):
     TODO: document kwargs
     """
     parameters = kwargs.pop('parameters', ())
-    t = Traceable(traceable, **kwargs)
-    out = t.record_trace(args, parameters)
-    return t.traces[0], out
+    return Traceable(traceable, **kwargs).record_trace(args, extra=parameters)
 
 
 def traced(traceable, **traced_kwargs):
@@ -225,6 +251,7 @@ def traced(traceable, **traced_kwargs):
         return traceable
     else:
         return t
+
 
 def trace(**kwargs):
     return lambda traceable: traced(traceable, **kwargs)


### PR DESCRIPTION
* Variables now hold a list of ValueTracingStates and can participate
in multiple traces.
* Refactored Traceable to maintain a list of traces, and only stop
tracing once it records all stages

Also:
* Traceable will now select a different trace for each configuration of input arguments (added to this PR to fix model tests)