### PR TITLE
Update to latest ToffeeIR protobuf.

### DIFF
--- a/test/expect/TestModels.test_alexnet-pbtxt.expect
+++ b/test/expect/TestModels.test_alexnet-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "17"
   input: "1"
@@ -404,3 +403,4 @@ input: "15"
 input: "16"
 input: "17"
 output: "50"
+producer_version: 1

--- a/test/expect/TestModels.test_concat-pbtxt.expect
+++ b/test/expect/TestModels.test_concat-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "1"
   input: "2"
@@ -14,3 +13,4 @@ name: "torch-jit-export"
 input: "1"
 input: "2"
 output: "4"
+producer_version: 1

--- a/test/expect/TestModels.test_ops-pbtxt.expect
+++ b/test/expect/TestModels.test_ops-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "5"
   output: "6"
@@ -94,3 +93,4 @@ input: "3"
 input: "4"
 input: "5"
 output: "5"
+producer_version: 1

--- a/test/expect/TestModels.test_permute-pbtxt.expect
+++ b/test/expect/TestModels.test_permute-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "1"
   output: "2"
@@ -14,3 +13,4 @@ node {
 name: "torch-jit-export"
 input: "1"
 output: "2"
+producer_version: 1

--- a/test/expect/TestModels.test_squeezenet-1_0-pbtxt.expect
+++ b/test/expect/TestModels.test_squeezenet-1_0-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "53"
   input: "1"
@@ -1258,3 +1257,4 @@ input: "51"
 input: "52"
 input: "53"
 output: "138"
+producer_version: 1

--- a/test/expect/TestModels.test_squeezenet-1_1-pbtxt.expect
+++ b/test/expect/TestModels.test_squeezenet-1_1-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "53"
   input: "1"
@@ -1258,3 +1257,4 @@ input: "51"
 input: "52"
 input: "53"
 output: "138"
+producer_version: 1

--- a/test/expect/TestModels.test_super_resolution-pbtxt.expect
+++ b/test/expect/TestModels.test_super_resolution-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "9"
   input: "1"
@@ -199,3 +198,4 @@ input: "7"
 input: "8"
 input: "9"
 output: "22"
+producer_version: 1

--- a/test/expect/TestModels.test_vgg-16-pbtxt.expect
+++ b/test/expect/TestModels.test_vgg-16-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "33"
   input: "1"
@@ -778,3 +777,4 @@ input: "31"
 input: "32"
 input: "33"
 output: "84"
+producer_version: 1

--- a/test/expect/TestModels.test_vgg-19-pbtxt.expect
+++ b/test/expect/TestModels.test_vgg-19-pbtxt.expect
@@ -1,4 +1,3 @@
-version: 1
 node {
   input: "39"
   input: "1"
@@ -898,3 +897,4 @@ input: "37"
 input: "38"
 input: "39"
 output: "96"
+producer_version: 1

--- a/tools/gen_toffee.sh
+++ b/tools/gen_toffee.sh
@@ -2,6 +2,9 @@
 set -ex
 # Assumed to be run like tools/gen_toffee.sh
 (cd torch/lib/nanopb/generator/proto && make)
+# It always searches the same dir as the proto, so
+# we have got to copy the option file over
+cp torch/csrc/toffee.options torch/lib/ToffeeIR/toffee/toffee.options
 protoc --plugin=protoc-gen-nanopb=$PWD/torch/lib/nanopb/generator/protoc-gen-nanopb \
        torch/lib/ToffeeIR/toffee/toffee.proto \
        --nanopb_out=-T:.

--- a/torch/csrc/toffee.cpp
+++ b/torch/csrc/toffee.cpp
@@ -24,7 +24,7 @@ bool micropb_encode<double, nullptr>(pb_ostream_t *stream, double* arg) {
 }
 
 // TODO: I'm not entirely sure why this can't be in the header...
-bool micropb_callback_tensor(pb_ostream_t *stream, const pb_field_t *field, void * const *arg) {
+bool micropb_callback_string_from_tensor(pb_ostream_t *stream, const pb_field_t *field, void * const *arg) {
   at::Tensor* t = static_cast<at::Tensor*>(*arg);
   JIT_ASSERT(t->is_contiguous());
   // Packed array format!

--- a/torch/csrc/toffee.options
+++ b/torch/csrc/toffee.options
@@ -1,0 +1,18 @@
+# Note [Callback for nested messages]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# nanopb's default translation for a nested, non-repeated (possibly
+# optional) message is to include it *inline* (no indirection), with
+# a boolean has_g/has_t field to indicate its presence or not.  Why
+# do we not like this?  It's not compatible with our ownership model,
+# where a TensorProto/GraphProto class owns the protobuf struct it
+# is constructing.  With the default translation, the protobuf struct
+# occurs in two places: a TensorProto, AND the parent protobuf struct
+# field.  That's bad.  Turning it back into a callback solves the
+# ownership problem.
+#
+# Two more bonuses: at the cost of an indirection, we no longer waste fields
+# when we aren't actually storing a graph/tensor; furthermore, circular
+# dependencies now work!
+
+toffee.AttributeProto.g type:FT_CALLBACK
+toffee.AttributeProto.t type:FT_CALLBACK

--- a/torch/csrc/toffee.pb.cpp
+++ b/torch/csrc/toffee.pb.cpp
@@ -10,48 +10,55 @@
 
 
 
-const pb_field_t toffee_AttributeProto_fields[10] = {
+const pb_field_t toffee_AttributeProto_fields[12] = {
     PB_FIELD(  1, STRING  , OPTIONAL, CALLBACK, FIRST, toffee_AttributeProto, name, name, 0),
     PB_FIELD(  2, FLOAT   , OPTIONAL, STATIC  , OTHER, toffee_AttributeProto, f, name, 0),
     PB_FIELD(  3, INT64   , OPTIONAL, STATIC  , OTHER, toffee_AttributeProto, i, f, 0),
     PB_FIELD(  4, BYTES   , OPTIONAL, CALLBACK, OTHER, toffee_AttributeProto, s, i, 0),
-    PB_FIELD(  5, FLOAT   , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, floats, s, 0),
-    PB_FIELD(  6, INT64   , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, ints, floats, 0),
-    PB_FIELD(  7, BYTES   , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, strings, ints, 0),
-    PB_FIELD(  8, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, tensors, strings, &toffee_TensorProto_fields),
-    PB_FIELD(  9, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, graphs, tensors, &toffee_GraphProto_fields),
+    PB_FIELD(  5, MESSAGE , OPTIONAL, CALLBACK, OTHER, toffee_AttributeProto, t, s, &toffee_TensorProto_fields),
+    PB_FIELD(  6, MESSAGE , OPTIONAL, CALLBACK, OTHER, toffee_AttributeProto, g, t, &toffee_GraphProto_fields),
+    PB_FIELD(  7, FLOAT   , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, floats, g, 0),
+    PB_FIELD(  8, INT64   , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, ints, floats, 0),
+    PB_FIELD(  9, BYTES   , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, strings, ints, 0),
+    PB_FIELD( 10, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, tensors, strings, &toffee_TensorProto_fields),
+    PB_FIELD( 11, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_AttributeProto, graphs, tensors, &toffee_GraphProto_fields),
     PB_LAST_FIELD
 };
 
-const pb_field_t toffee_NodeProto_fields[6] = {
+const pb_field_t toffee_NodeProto_fields[7] = {
     PB_FIELD(  1, STRING  , REPEATED, CALLBACK, FIRST, toffee_NodeProto, input, input, 0),
     PB_FIELD(  2, STRING  , REPEATED, CALLBACK, OTHER, toffee_NodeProto, output, input, 0),
     PB_FIELD(  3, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_NodeProto, name, output, 0),
     PB_FIELD(  4, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_NodeProto, op_type, name, 0),
     PB_FIELD(  5, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_NodeProto, attribute, op_type, &toffee_AttributeProto_fields),
+    PB_FIELD(  6, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_NodeProto, doc_string, attribute, 0),
     PB_LAST_FIELD
 };
 
-const pb_field_t toffee_GraphProto_fields[7] = {
-    PB_FIELD(  1, INT64   , OPTIONAL, STATIC  , FIRST, toffee_GraphProto, version, version, 0),
-    PB_FIELD(  2, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_GraphProto, node, version, &toffee_NodeProto_fields),
-    PB_FIELD(  3, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_GraphProto, name, node, 0),
-    PB_FIELD(  4, STRING  , REPEATED, CALLBACK, OTHER, toffee_GraphProto, input, name, 0),
-    PB_FIELD(  5, STRING  , REPEATED, CALLBACK, OTHER, toffee_GraphProto, output, input, 0),
-    PB_FIELD(  6, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_GraphProto, initializer, output, &toffee_TensorProto_fields),
+const pb_field_t toffee_GraphProto_fields[11] = {
+    PB_FIELD(  1, MESSAGE , REPEATED, CALLBACK, FIRST, toffee_GraphProto, node, node, &toffee_NodeProto_fields),
+    PB_FIELD(  2, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_GraphProto, name, node, 0),
+    PB_FIELD(  3, STRING  , REPEATED, CALLBACK, OTHER, toffee_GraphProto, input, name, 0),
+    PB_FIELD(  4, STRING  , REPEATED, CALLBACK, OTHER, toffee_GraphProto, output, input, 0),
+    PB_FIELD(  5, MESSAGE , REPEATED, CALLBACK, OTHER, toffee_GraphProto, initializer, output, &toffee_TensorProto_fields),
+    PB_FIELD(  6, INT64   , OPTIONAL, STATIC  , OTHER, toffee_GraphProto, producer_version, initializer, 0),
+    PB_FIELD(  7, INT64   , OPTIONAL, STATIC  , OTHER, toffee_GraphProto, ir_version, producer_version, 0),
+    PB_FIELD(  8, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_GraphProto, version_tag, ir_version, 0),
+    PB_FIELD(  9, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_GraphProto, domain, version_tag, 0),
+    PB_FIELD( 10, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_GraphProto, doc_string, domain, 0),
     PB_LAST_FIELD
 };
 
 const pb_field_t toffee_TensorProto_fields[10] = {
     PB_FIELD(  1, INT64   , REPEATED, CALLBACK, FIRST, toffee_TensorProto, dims, dims, 0),
     PB_FIELD(  2, UENUM   , OPTIONAL, STATIC  , OTHER, toffee_TensorProto, data_type, dims, 0),
-    PB_FIELD(  3, FLOAT   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, float_data, data_type, 0),
+    PB_FIELD(  3, MESSAGE , OPTIONAL, STATIC  , OTHER, toffee_TensorProto, segment, data_type, &toffee_TensorProto_Segment_fields),
+    PB_FIELD(  4, FLOAT   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, float_data, segment, 0),
     PB_FIELD(  5, INT32   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, int32_data, float_data, 0),
     PB_FIELD(  6, BYTES   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, string_data, int32_data, 0),
     PB_FIELD(  7, INT64   , REPEATED, CALLBACK, OTHER, toffee_TensorProto, int64_data, string_data, 0),
     PB_FIELD(  8, STRING  , OPTIONAL, CALLBACK, OTHER, toffee_TensorProto, name, int64_data, 0),
-    PB_FIELD(  9, MESSAGE , OPTIONAL, STATIC  , OTHER, toffee_TensorProto, segment, name, &toffee_TensorProto_Segment_fields),
-    PB_FIELD( 10, BYTES   , OPTIONAL, CALLBACK, OTHER, toffee_TensorProto, raw_data, segment, 0),
+    PB_FIELD(  9, BYTES   , OPTIONAL, CALLBACK, OTHER, toffee_TensorProto, raw_data, name, 0),
     PB_LAST_FIELD
 };
 

--- a/torch/csrc/toffee.pb.h
+++ b/torch/csrc/toffee.pb.h
@@ -16,11 +16,11 @@ extern "C" {
 
 /* Enum definitions */
 typedef enum _toffee_Version {
-    toffee_Version_CURRENT_VERSION = 1
+    toffee_Version_PRODUCER_VERSION = 1
 } toffee_Version;
-#define _toffee_Version_MIN toffee_Version_CURRENT_VERSION
-#define _toffee_Version_MAX toffee_Version_CURRENT_VERSION
-#define _toffee_Version_ARRAYSIZE ((toffee_Version)(toffee_Version_CURRENT_VERSION+1))
+#define _toffee_Version_MIN toffee_Version_PRODUCER_VERSION
+#define _toffee_Version_MAX toffee_Version_PRODUCER_VERSION
+#define _toffee_Version_ARRAYSIZE ((toffee_Version)(toffee_Version_PRODUCER_VERSION+1))
 
 typedef enum _toffee_TensorProto_DataType {
     toffee_TensorProto_DataType_UNDEFINED = 0,
@@ -46,6 +46,7 @@ typedef struct _toffee_NodeProto {
     pb_callback_t name;
     pb_callback_t op_type;
     pb_callback_t attribute;
+    pb_callback_t doc_string;
 /* @@protoc_insertion_point(struct:toffee_NodeProto) */
 } toffee_NodeProto;
 
@@ -56,6 +57,8 @@ typedef struct _toffee_AttributeProto {
     bool has_i;
     int64_t i;
     pb_callback_t s;
+    pb_callback_t t;
+    pb_callback_t g;
     pb_callback_t floats;
     pb_callback_t ints;
     pb_callback_t strings;
@@ -65,13 +68,18 @@ typedef struct _toffee_AttributeProto {
 } toffee_AttributeProto;
 
 typedef struct _toffee_GraphProto {
-    bool has_version;
-    int64_t version;
     pb_callback_t node;
     pb_callback_t name;
     pb_callback_t input;
     pb_callback_t output;
     pb_callback_t initializer;
+    bool has_producer_version;
+    int64_t producer_version;
+    bool has_ir_version;
+    int64_t ir_version;
+    pb_callback_t version_tag;
+    pb_callback_t domain;
+    pb_callback_t doc_string;
 /* @@protoc_insertion_point(struct:toffee_GraphProto) */
 } toffee_GraphProto;
 
@@ -87,13 +95,13 @@ typedef struct _toffee_TensorProto {
     pb_callback_t dims;
     bool has_data_type;
     toffee_TensorProto_DataType data_type;
+    bool has_segment;
+    toffee_TensorProto_Segment segment;
     pb_callback_t float_data;
     pb_callback_t int32_data;
     pb_callback_t string_data;
     pb_callback_t int64_data;
     pb_callback_t name;
-    bool has_segment;
-    toffee_TensorProto_Segment segment;
     pb_callback_t raw_data;
 /* @@protoc_insertion_point(struct:toffee_TensorProto) */
 } toffee_TensorProto;
@@ -110,16 +118,16 @@ typedef struct _toffee_SparseTensorProto {
 /* Default values for struct fields */
 
 /* Initializer values for message structs */
-#define toffee_AttributeProto_init_default       {{{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_NodeProto_init_default            {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_GraphProto_init_default           {false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_TensorProto_init_default          {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, toffee_TensorProto_Segment_init_default, {{NULL}, NULL}}
+#define toffee_AttributeProto_init_default       {{{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
+#define toffee_NodeProto_init_default            {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
+#define toffee_GraphProto_init_default           {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
+#define toffee_TensorProto_init_default          {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, false, toffee_TensorProto_Segment_init_default, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
 #define toffee_TensorProto_Segment_init_default  {false, 0, false, 0}
 #define toffee_SparseTensorProto_init_default    {{{NULL}, NULL}, false, toffee_TensorProto_init_default, false, toffee_TensorProto_init_default}
-#define toffee_AttributeProto_init_zero          {{{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_NodeProto_init_zero               {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_GraphProto_init_zero              {false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
-#define toffee_TensorProto_init_zero             {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, toffee_TensorProto_Segment_init_zero, {{NULL}, NULL}}
+#define toffee_AttributeProto_init_zero          {{{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
+#define toffee_NodeProto_init_zero               {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
+#define toffee_GraphProto_init_zero              {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, false, 0, false, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
+#define toffee_TensorProto_init_zero             {{{NULL}, NULL}, false, (toffee_TensorProto_DataType)0, false, toffee_TensorProto_Segment_init_zero, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}}
 #define toffee_TensorProto_Segment_init_zero     {false, 0, false, 0}
 #define toffee_SparseTensorProto_init_zero       {{{NULL}, NULL}, false, toffee_TensorProto_init_zero, false, toffee_TensorProto_init_zero}
 
@@ -129,40 +137,47 @@ typedef struct _toffee_SparseTensorProto {
 #define toffee_NodeProto_name_tag                3
 #define toffee_NodeProto_op_type_tag             4
 #define toffee_NodeProto_attribute_tag           5
+#define toffee_NodeProto_doc_string_tag          6
 #define toffee_AttributeProto_name_tag           1
 #define toffee_AttributeProto_f_tag              2
 #define toffee_AttributeProto_i_tag              3
 #define toffee_AttributeProto_s_tag              4
-#define toffee_AttributeProto_floats_tag         5
-#define toffee_AttributeProto_ints_tag           6
-#define toffee_AttributeProto_strings_tag        7
-#define toffee_AttributeProto_tensors_tag        8
-#define toffee_AttributeProto_graphs_tag         9
-#define toffee_GraphProto_version_tag            1
-#define toffee_GraphProto_node_tag               2
-#define toffee_GraphProto_name_tag               3
-#define toffee_GraphProto_input_tag              4
-#define toffee_GraphProto_output_tag             5
-#define toffee_GraphProto_initializer_tag        6
+#define toffee_AttributeProto_t_tag              5
+#define toffee_AttributeProto_g_tag              6
+#define toffee_AttributeProto_floats_tag         7
+#define toffee_AttributeProto_ints_tag           8
+#define toffee_AttributeProto_strings_tag        9
+#define toffee_AttributeProto_tensors_tag        10
+#define toffee_AttributeProto_graphs_tag         11
+#define toffee_GraphProto_node_tag               1
+#define toffee_GraphProto_name_tag               2
+#define toffee_GraphProto_input_tag              3
+#define toffee_GraphProto_output_tag             4
+#define toffee_GraphProto_initializer_tag        5
+#define toffee_GraphProto_producer_version_tag   6
+#define toffee_GraphProto_ir_version_tag         7
+#define toffee_GraphProto_version_tag_tag        8
+#define toffee_GraphProto_domain_tag             9
+#define toffee_GraphProto_doc_string_tag         10
 #define toffee_TensorProto_Segment_begin_tag     1
 #define toffee_TensorProto_Segment_end_tag       2
 #define toffee_TensorProto_dims_tag              1
 #define toffee_TensorProto_data_type_tag         2
-#define toffee_TensorProto_float_data_tag        3
+#define toffee_TensorProto_segment_tag           3
+#define toffee_TensorProto_float_data_tag        4
 #define toffee_TensorProto_int32_data_tag        5
 #define toffee_TensorProto_string_data_tag       6
 #define toffee_TensorProto_int64_data_tag        7
 #define toffee_TensorProto_name_tag              8
-#define toffee_TensorProto_segment_tag           9
-#define toffee_TensorProto_raw_data_tag          10
+#define toffee_TensorProto_raw_data_tag          9
 #define toffee_SparseTensorProto_dims_tag        1
 #define toffee_SparseTensorProto_indices_tag     2
 #define toffee_SparseTensorProto_values_tag      3
 
 /* Struct field encoding specification for nanopb */
-extern const pb_field_t toffee_AttributeProto_fields[10];
-extern const pb_field_t toffee_NodeProto_fields[6];
-extern const pb_field_t toffee_GraphProto_fields[7];
+extern const pb_field_t toffee_AttributeProto_fields[12];
+extern const pb_field_t toffee_NodeProto_fields[7];
+extern const pb_field_t toffee_GraphProto_fields[11];
 extern const pb_field_t toffee_TensorProto_fields[10];
 extern const pb_field_t toffee_TensorProto_Segment_fields[3];
 extern const pb_field_t toffee_SparseTensorProto_fields[4];

--- a/torch/csrc/toffee/export.cpp
+++ b/torch/csrc/toffee/export.cpp
@@ -201,7 +201,7 @@ static void encodeTensor(toffee::TensorProto * p, const at::Tensor & tensor) {
     }
     p->set_data_type(toffee_type);
     at::Tensor cont = tensor.toType(at::CPU(at_type)).contiguous();
-    p->add_tensor(cont);
+    p->set_raw_data(cont);
 }
 static void encodeGraph(toffee::GraphProto * p_g, std::shared_ptr<Graph> & g, const std::vector<at::Tensor> & initializers);
 static void addAttribute(toffee::NodeProto * n_p, jit::Node * n, jit::Symbol name) {


### PR DESCRIPTION
This was a doozy!

- 'namespace' is a C++ reserved keyword, so if you have a field named
  this, nanopb will blithely export some malformed C++.  I submitted
  a PR for this: https://github.com/ProjectToffee/ToffeeIR/pull/88

- Zach added support for singular tensor and graph.  While attempting
  to add support for these, I realized that it was actually impossible
  to support them under the default protobuf translation.  The gory
  details are in Note [Callback for nested messages].  The singular
  callbacks needed a new helper which I dubbed msg; it's just
  the singular version of list.

- While I was working on the API, I braino'd with the tensor()
  method.  It turns out this is totally not the right way to think
  about it; it's more string_from_tensor().  So I renamed it.
  I also renamed add_tensor to set_raw_data; add_tensor is a misnomer
  since it implies you can add multiple tensors, which is not true.

- version turned into producer_version.  Actually, this is a bit
  questionable and might change soon.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>