### PR TITLE
Add primspec for Sub, Index, Chunk, and Embedding

### DIFF
--- a/torch/autograd/_functions/basic_ops.py
+++ b/torch/autograd/_functions/basic_ops.py
@@ -30,7 +30,7 @@ class Sub(InplaceFunction):
 
     @staticmethod
     def primspec(g, a, b, inplace=False):
-        #TODO: [Export inplace]
+        # TODO: [Export inplace]
         return g.appendNode(g.create("Sub", [a, b]))
 
     @staticmethod

--- a/torch/autograd/_functions/basic_ops.py
+++ b/torch/autograd/_functions/basic_ops.py
@@ -29,6 +29,11 @@ class Add(InplaceFunction):
 class Sub(InplaceFunction):
 
     @staticmethod
+    def primspec(g, a, b, inplace=False):
+        #TODO: [Export inplace]
+        return g.appendNode(g.create("Sub", [a, b]))
+
+    @staticmethod
     def forward(ctx, a, b, inplace=False):
         ctx.a_size = a.size()
         ctx.b_size = b.size()

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -10,6 +10,28 @@ from .utils import maybe_unexpand
 class Index(Function):
 
     @staticmethod
+    def primspec(g, i, index):
+        # We should only expect index as an integer in this case.
+        # We use "Slice" to get the index-th element in i,
+        # Then we reduce the dimension using "Reshape".
+        if not isinstance(index, int):
+            raise ValueError('Right now, only int-type index is suppported.')
+        starts = [0] * len(i.type().sizes())
+        starts[0] = index
+        starts_tensor = torch.IntTensor(starts)
+        starts_node = g.appendNode(g.create("Constant").t_("Value", starts_tensor))
+        ends = list(i.type().sizes())
+        ends_tensor = torch.IntTensor(ends)
+        ends_node = g.appendNode(g.create("Constant").t_("Value", ends_tensor))
+        sizes = list(i.type().sizes())
+        sizes.pop(0)
+        slice_output = g.appendNode(g.create("Slice", [i, starts_node, ends_node]))
+        reshape_output = g.appendNode(g.create("Reshape", [slice_output]).is_("shape", sizes))
+        real_output = g.appendNode(g.createSelect(reshape_output, 0))
+        nouse_output = g.appendNode(g.createSelect(reshape_output, 1))
+        return real_output
+
+    @staticmethod
     def forward(ctx, i, index):
         ctx.input_size = i.size()
         ctx.index = index
@@ -574,6 +596,21 @@ class Topk(_MultiSelectionFunction):
 
 
 class Chunk(Function):
+
+    @staticmethod
+    def primspec(g, i, num_chunks, dim=0):
+        dim_size = i.type().sizes()[dim]
+        split_size = (dim_size + num_chunks - 1) // num_chunks
+        lengths = []
+        while (dim_size > 0):
+            this_split_size = split_size if dim_size >= split_size else dim_size
+            lengths.append(this_split_size)
+            dim_size = dim_size - split_size
+        result = []
+        n = g.appendNode(g.create("Split", [i]).is_("split", lengths).i_("axis", dim))
+        for i in range(num_chunks):
+            result.append(g.appendNode(g.createSelect(n, i)))
+        return tuple(result)
 
     @staticmethod
     def forward(ctx, i, num_chunks, dim=0):

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -23,8 +23,7 @@ class Index(Function):
         ends = list(i.type().sizes())
         ends_tensor = torch.IntTensor(ends)
         ends_node = g.appendNode(g.create("Constant").t_("Value", ends_tensor))
-        sizes = list(i.type().sizes())
-        sizes.pop(0)
+        sizes = i.type().sizes()[1:]
         slice_output = g.appendNode(g.create("Slice", [i, starts_node, ends_node]))
         reshape_output = g.appendNode(g.create("Reshape", [slice_output]).is_("shape", sizes))
         real_output = g.appendNode(g.createSelect(reshape_output, 0))

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -9,6 +9,12 @@ from . import _all_functions
 class Embedding(Function):
 
     @staticmethod
+    def primspec(g, indices, weight, padding_idx, max_norm, norm_type, scale_grad_by_freq,
+                 sparse=False):
+        # TODO More checks on the parameters.
+        return g.appendNode(g.create("Gather", [weight, indices]))
+
+    @staticmethod
     def _renorm(ctx, indices, weight, max_norm, norm_type):
         # clone indices since LookupTable_renorm modifies it in-place
         ctx._backend.LookupTable_renorm(

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -11,8 +11,23 @@ class Embedding(Function):
     @staticmethod
     def primspec(g, indices, weight, padding_idx, max_norm, norm_type, scale_grad_by_freq,
                  sparse=False):
-        # TODO More checks on the parameters.
-        return g.appendNode(g.create("Gather", [weight, indices]))
+        if max_norm is not None:
+            raise ValueError('Right now, re-norm is not supported.')
+
+        # To support padding_idx, we set the corresponding element to 0 in weight.
+        if padding_idx is not None:
+            if padding_idx < 0:
+                padding_idx = padding_idx + len(weight.type().sizes())
+            shape = list(weight.type().sizes())
+            mask = torch.FloatTensor(*shape)
+            mask.fill_(1.0)
+            index = torch.LongTensor([padding_idx])
+            mask.index_fill_(0, index, 0.0)
+            mask_node = g.appendNode(g.create("Constant").t_("Value", mask))
+            weight = g.appendNode(g.create("Mul", [weight, mask_node]))
+
+        output = g.appendNode(g.create("Gather", [weight, indices]))
+        return output
 
     @staticmethod
     def _renorm(ctx, indices, weight, max_norm, norm_type):


### PR DESCRIPTION
Add primspec for Sub, Index, Chunk, and Embedding. These ops are used by word language model.