### PR TITLE
Update to ToffeeIR HEAD, minus BC-breaking MS changes.

### DIFF
--- a/test/model_defs/debug_embed_params.py
+++ b/test/model_defs/debug_embed_params.py
@@ -52,5 +52,5 @@ def test_embed_params(proto, model, input, state_dict=None, use_gpu=True):
         predict_graph=graph_def,
         inputs=W,
         use_gpu=use_gpu)
-    caffe2_out = list(caffe2_out_workspace.values())[0]
+    caffe2_out = caffe2_out_workspace[0]
     return caffe2_out

--- a/torch/for_toffee/toffee.py
+++ b/torch/for_toffee/toffee.py
@@ -19,5 +19,5 @@ def import_model(proto, input, workspace=None, use_gpu=True):
         predict_graph=graph_def,
         inputs=workspace,
         use_gpu=use_gpu)
-    caffe2_out = list(caffe2_out_workspace.values())[0]
+    caffe2_out = caffe2_out_workspace[0]
     return caffe2_out


### PR DESCRIPTION
This commit advances the ToffeeIR submodule pointer to
pr/hot-fixed-api, which is a TEMPORARY branch that tracks
ToffeeIR HEAD, but with the Microsoft breaking patches reverted.
This means we can develop against the new ToffeeIR API until
we can handle the MS changes, and then we can swing the pointer
back to master.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>