### PR TITLE
Try to handle NULL Variables in the tracer

### DIFF
--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -63,6 +63,11 @@ variable_list Function::tracedApply(variable_list inputs) {
   int num_outputs = outputs.size();
   for (int i = 0; i < num_outputs; ++i) {
     auto& output = outputs[i];
+    if (!output) {
+      auto & edge = next_functions[i];
+      auto & meta = edge.first->input_sizes.at(edge.second);
+      output = meta.recreate();
+    }
     Node* sel = graph->appendNode(graph->createSelect(this_node, i));
     sel->inferTypeFrom(output->data);
     tracer::setValueTrace(state, output, sel);

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -27,6 +27,23 @@ using edge_type = std::pair<std::shared_ptr<Function>, int>;
 using function_list = std::vector<edge_type>;
 using saved_variable_list = std::vector<SavedVariable>;
 
+struct TensorMeta {
+  TensorMeta(const std::shared_ptr<Variable>& var)
+    : sizes(var->data.sizes())
+    , device(var->data.type().isCuda() ? var->data.get_device() : -1)
+    , type(var->data.type()) {}
+
+  std::shared_ptr<Variable> recreate() {
+    AutoGPU gpu_guard(device);
+    return std::make_shared<Variable>(type.tensor(sizes), false, false);
+  }
+
+  std::vector<int64_t> sizes;
+  int device;
+  at::Type& type;
+};
+using tensor_meta_list = std::vector<TensorMeta>;
+
 struct edge_hasher {
   std::size_t operator()(const edge_type& edge) const {
 #define HASH_IDX(idx) std::hash<std::tuple_element<idx, edge_type>::type>()(std::get<idx>(edge))
@@ -139,6 +156,7 @@ struct Function : std::enable_shared_from_this<Function> {
 
   int num_inputs;
   function_list next_functions;
+  tensor_meta_list input_sizes;
   bool is_executable;
   bool is_stochastic;
   std::vector<std::shared_ptr<FunctionPreHook>> pre_hooks;

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -28,19 +28,26 @@ using function_list = std::vector<edge_type>;
 using saved_variable_list = std::vector<SavedVariable>;
 
 struct TensorMeta {
-  TensorMeta(const std::shared_ptr<Variable>& var)
-    : sizes(var->data.sizes())
-    , device(var->data.type().isCuda() ? var->data.get_device() : -1)
-    , type(var->data.type()) {}
+  TensorMeta(const std::shared_ptr<Variable>& var) {
+    defined = static_cast<bool>(var);
+    if (defined) {
+      sizes = var->data.sizes();
+      device = var->data.type().isCuda() ? var->data.get_device() : -1;
+      type = &var->data.type();
+    }
+  }
 
   std::shared_ptr<Variable> recreate() {
     AutoGPU gpu_guard(device);
-    return std::make_shared<Variable>(type.tensor(sizes), false, false);
+    if (!defined)
+      throw std::logic_error("Recreating undefined TensorMeta");
+    return std::make_shared<Variable>(type->zeros(sizes), false, false);
   }
 
   std::vector<int64_t> sizes;
   int device;
-  at::Type& type;
+  at::Type* type;
+  bool defined;
 };
 using tensor_meta_list = std::vector<TensorMeta>;
 

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -13,6 +13,7 @@ AccumulateGrad::AccumulateGrad(std::shared_ptr<Variable> _variable)
     , variable_grad(_variable->grad) {
   is_executable = _variable->requires_grad;
   num_inputs = 1;
+  input_sizes.emplace_back(_variable);
 }
 
 auto AccumulateGrad::acc_inplace(std::shared_ptr<Variable>& grad,

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -28,7 +28,6 @@ struct Replicate : public Function {
   }
 
   virtual variable_list apply(const variable_list& inputs) {
-    check_input_variables("Replicate", inputs, 1);
     return variable_list(next_functions.size(), inputs[0]);
   }
 };
@@ -103,6 +102,17 @@ struct SimpleEval : public Function {
   }
 
   std::shared_ptr<Function> fn;
+};
+
+struct EmitNull : public Function {
+  EmitNull() {
+    is_executable = true;
+    num_inputs = 0;
+  }
+
+  virtual variable_list apply(const variable_list& inputs) {
+    return {nullptr};
+  };
 };
 
 // Wraps a PythonOp and dispatches calls to Functions implemented in Python
@@ -501,6 +511,8 @@ struct StageClosure {
       return fn;
     IR_ELSEIF(Chunk)
       return std::make_shared<Chunk>(value->i(kNumChunks), value->i(kDim));
+    IR_ELSEIF(Undefined)
+      return std::make_shared<EmitNull>();
     IR_ELSE()
       throw std::runtime_error(std::string("unrecognized NodeKind: ") + symbolToString(node->kind()));
     IR_END()
@@ -675,7 +687,7 @@ AutogradClosure::AutogradClosure(const std::shared_ptr<MultiStageClosure>& desc,
     std::lock_guard<std::mutex> lock(this->capture_mutex);
     this->outputs.reserve(inputs.size());
     for (auto & input : inputs)
-      this->outputs.emplace_back(input->data);
+      this->outputs.emplace_back(input ? input->data : at::Tensor());
     return false; // Stop execution
   });
 
@@ -697,16 +709,15 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
   if (num_inputs != stage_closure.var_flags.size())
     throw std::runtime_error("AutogradClosure received an incorrect number of inputs");
   for (std::size_t i = 0; i < num_inputs; ++i) {
-    auto & input = inputs[i];
     auto & flags = stage_closure.var_flags[i];
-    if (input->requires_grad != flags.requires_grad || input->is_volatile != flags.is_volatile)
+    if (!flags.verify(inputs[i]))
       throw std::runtime_error("AutogradClosure received inputs with different flags");
   }
 
   // TODO: we could run all this with volatile variables, but we need to somehow capture handles
   // we should enable requires_grad only for the parts that need it
   auto input_leaves = fmap(inputs, [](const std::shared_ptr<Variable>& v) {
-    return std::make_shared<Variable>(v->data, v->requires_grad, v->is_volatile);
+    return v ? std::make_shared<Variable>(v->data, v->requires_grad, v->is_volatile) : nullptr;
   });
   for (auto unique : desc->stages[stage].prev_stage_variables)
     input_leaves.emplace_back(std::make_shared<Variable>(saved_vars.at(unique), true, false));

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -450,7 +450,7 @@ struct StageClosure {
           captured_variables.emplace_back(fn.get(), captured_node->i(kOffset), captured_node->unique());
         } else {
           JIT_ASSERT(captured_node->type()->kind() == TypeKind::HandleType);
-          captured_handles.emplace_back(fn.get(), captured_node->unique());
+          captured_handles.emplace(fn.get(), captured_node->unique());
         }
       } else {
         JIT_ASSERT(captured_node->type()->kind() == TypeKind::TensorType);
@@ -616,7 +616,7 @@ struct StageClosure {
   // After the function is run, take either a Variable or a backward handle, and
   // put it in the environment under 'unique'.
   std::vector<std::tuple<Function*, int, int>> captured_variables;  // (function, output_nr, unique)
-  std::vector<std::pair<Function*, int>> captured_handles;          // (function, unique)
+  std::unordered_map<Function*, int> captured_handles;              // (function, unique)
 };
 
 // Computes and stores an array of StageClosures for each stage in the graph
@@ -662,24 +662,35 @@ AutogradClosure::AutogradClosure(const std::shared_ptr<MultiStageClosure>& desc,
   for (auto & entry : stage_desc.captured_handles) {
     auto & fn = entry.first;
     auto saved_idx = entry.second;
-    // Evals already wrap their backwards
-    if (dynamic_cast<Eval*>(fn)) {
-      post_callbacks.emplace(fn, [this, saved_idx](Function* fn, variable_list& inputs, variable_list& outputs) {
+    // Evals already wrap their backwards and they will be handled in the
+    // next loop if needed
+    if (dynamic_cast<EvalPlaceholder*>(fn)) continue;
+    // Otherwise we have to wrap the backwards in a handle ourselves
+    post_callbacks.emplace(fn, [this, saved_idx](Function* fn, variable_list& inputs, variable_list& outputs) {
+      auto eval_fn = std::make_shared<Eval>();
+      eval_fn->replaceSubgraph(inputs, outputs);
+      std::lock_guard<std::mutex> lock(this->capture_mutex);
+      this->captured_handles[saved_idx] = std::move(eval_fn);
+      return true;
+    });
+  }
+
+  // Callbacks that run closures received from forward and optionally capture
+  // them for next stages
+  for (auto & entry : stage_desc.prev_stage_handles) {
+    int unique = entry.second;
+    // Check if we need to capture the handle for next stage too
+    auto it = stage_desc.captured_handles.find(entry.first);
+    int saved_idx = it == stage_desc.captured_handles.end() ? -1 : it->second;
+    post_callbacks.emplace(entry.first, [this, unique, saved_idx](Function* fn, variable_list& inputs, variable_list& outputs) {
+      outputs = (*this->saved_handles.at(unique))(inputs);
+      if (saved_idx != -1) {
         auto eval_fn = Eval::getBackwardEval(inputs, outputs);
         std::lock_guard<std::mutex> lock(this->capture_mutex);
         this->captured_handles[saved_idx] = std::move(eval_fn);
-        return true;
-      });
-    // Otherwise we have to wrap the backwards in a handle ourselves
-    } else {
-      post_callbacks.emplace(fn, [this, saved_idx](Function* fn, variable_list& inputs, variable_list& outputs) {
-        auto eval_fn = std::make_shared<Eval>();
-        eval_fn->replaceSubgraph(inputs, outputs);
-        std::lock_guard<std::mutex> lock(this->capture_mutex);
-        this->captured_handles[saved_idx] = std::move(eval_fn);
-        return true;
-      });
-    }
+      }
+      return true;
+    });
   }
 
   // A callback to capture the output
@@ -690,15 +701,6 @@ AutogradClosure::AutogradClosure(const std::shared_ptr<MultiStageClosure>& desc,
       this->outputs.emplace_back(input ? input->data : at::Tensor());
     return false; // Stop execution
   });
-
-  // Callbacks that run closures received from forward
-  for (auto & entry : stage_desc.prev_stage_handles) {
-    int unique = entry.second;
-    pre_callbacks.emplace(entry.first, [this, unique](Function* fn, variable_list& inputs) {
-      inputs = (*this->saved_handles.at(unique))(inputs);
-      return true;
-    });
-  }
 }
 
 variable_list AutogradClosure::apply(const variable_list& inputs) {

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -168,6 +168,7 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
   next_functions.insert(next_functions.begin(), subgraph.boundary.ends.begin(), subgraph.boundary.ends.end());
   is_executable = std::any_of(relevant_outputs.begin(), relevant_outputs.end(),
                               [](std::shared_ptr<Variable>& var) { return var->requires_grad; });
+  input_sizes = fmap<TensorMeta>(relevant_outputs);
 
   // Ensure placeholders and inputs are sorted in the same way.
   edge_order input_order = computeInputOrder(inputs, inherited_placeholders);

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -20,6 +20,7 @@ struct EvalOutput : Function {
     // confuse some of the functions causing them to do unnecessary work.
     // TODO: it should be possible to improve this once we get rid of NULL Variables
     is_executable = true;
+    input_sizes.emplace_back(next_edge.first->input_sizes.at(next_edge.second));
   }
 
   virtual variable_list apply(const variable_list& inputs) override {

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -85,6 +85,7 @@ struct Eval : Function {
   bool traceable = false;
 
 private:
+  std::pair<function_list, variable_list> filterRoots(const variable_list& inputs);
   Engine::pre_callback_map getCallbacks(variable_list& outputs, std::mutex& outputs_mutex);
 
   Subgraph getSubgraph(

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -1,4 +1,6 @@
 #include "torch/csrc/autograd/functions/utils.h"
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/jit/tracer.h"
 
 #include <sstream>
 
@@ -23,6 +25,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
         result.emplace_back(nullptr);
       }
     }
+    grad_fn->input_sizes = fmap<TensorMeta>(result);
   }
   return result;
 }

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -641,6 +641,12 @@ PyObject* process_outputs(THPFunction* grad_fn, const UnpackedInput& unpacked, T
     grad_fn->non_differentiable = NULL;
   }
 
+  grad_fn->cdata.input_sizes.reserve(num_outputs);
+  for (int i = 0; i < num_outputs; ++i) {
+    THPVariable* py_var = (THPVariable*)PyTuple_GET_ITEM(outputs.get(), i);
+    grad_fn->cdata.input_sizes.emplace_back(py_var->cdata);
+  }
+
   // Unpack the output, unless .forward() returned a tuple
   if (unpack_output) {
     PyObject *output = PyTuple_GET_ITEM(outputs.get(), 0);
@@ -651,7 +657,7 @@ PyObject* process_outputs(THPFunction* grad_fn, const UnpackedInput& unpacked, T
   return outputs.release();
 }
 
-static void trace_create(PyObject* op_obj,
+static void trace_create(PyObject* op_obj, THPFunction* bw_obj,
         PyObject *input_objects, PyObject *output_objects,
         const variable_list& input_vars, const std::vector<bool>& is_variable_input) {
   if (!tracer::isTracing(input_vars))
@@ -739,6 +745,7 @@ static void trace_create(PyObject* op_obj,
     tracer::nontraceableBackwardSubgraph(input_vars, output_vars);
     Function::setUpContextEdge(this_expr, num_outputs, input_vars, output_vars);
   }
+
 }
 
 // Legacy codepath
@@ -807,7 +814,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   THPObjectPtr outputs {process_outputs(ctx, unpacked_input, std::move(tensor_outputs),
                                         is_volatile)};
 
-  trace_create(cls, inputs, outputs, unpacked_input.input_vars, *ctx->is_variable_input);
+  trace_create(cls, ctx, inputs, outputs, unpacked_input.input_vars, *ctx->is_variable_input);
 
   return outputs.release();
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -50,8 +50,9 @@ struct TraceEval : autograd::Eval {
     graph->advanceStage();
 
     for (auto & input : inputs) {
-      JIT_ASSERT(!detail::getValueState(tracing_state, input, false));
       Node *input_node = graph->addInput();
+      if (!input) continue;
+      JIT_ASSERT(!detail::getValueState(tracing_state, input, false));
       setValueTrace(tracing_state, input, input_node);
       input_node->inferTypeFrom(input->data);
     }
@@ -83,13 +84,6 @@ void traceBackward(const std::shared_ptr<TracingState>& tracing_state, const var
 }
 
 } // namespace detail
-
-VariableFlags VariableFlags::create(const std::shared_ptr<Variable>& var) {
-  VariableFlags f;
-  f.requires_grad = var->requires_grad;
-  f.is_volatile = var->is_volatile;
-  return f;
-}
 
 void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_list& outputs) {
   std::make_shared<autograd::Eval>()->replaceSubgraph(inputs, outputs);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -52,7 +52,7 @@ inline bool isElemActive(const ValueTracingStateElem& vts) {
 }
 
 inline std::vector<VariableFlags> getVarFlags(const variable_list& vars) {
-  return fmap(vars, &VariableFlags::create);
+  return fmap(vars, &VariableFlags::of);
 }
 
 }
@@ -93,6 +93,7 @@ inline std::shared_ptr<TracingState> getTracingState(const variable_list& vars) 
 // 'setValueTrace' associates this node with an output variable, so that further operations
 // involving this variable know which node in the IR to reference.
 inline void setValueTrace(const std::shared_ptr<TracingState>& state, const std::shared_ptr<Variable>& var, Node *node) {
+  JIT_ASSERT(var != nullptr);
   auto vts = detail::getValueState(state, var);
   vts->trace = node;
 }
@@ -212,5 +213,24 @@ inline void exit(const variable_list& outputs) {
 // Marks part of the backward graph as non-traceable (i.e. one that should be replaced
 // with an Eval in the trace).
 void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_list& outputs);
+
+// These definitions require Variable struct to be defined, so they can't be
+// in tracer_state.h
+inline VariableFlags VariableFlags::of(const std::shared_ptr<Variable>& var) {
+  VariableFlags f;
+  if (var) {
+    f.was_null = false;
+    f.requires_grad = var->requires_grad;
+    f.is_volatile = var->is_volatile;
+  } else {
+    f.was_null = true;
+  }
+  return f;
+}
+
+inline bool VariableFlags::verify(const std::shared_ptr<Variable>& var) {
+  if (!var) return was_null;
+  return !was_null && requires_grad == var->requires_grad && is_volatile == var->is_volatile;
+}
 
 }}} // namespace torch::jit::tracer

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -34,10 +34,12 @@ using function_list = std::vector<std::pair<std::shared_ptr<Function>, int>>;
 // actual trace itself.
 
 struct VariableFlags {
-  static VariableFlags create(const std::shared_ptr<Variable>& var);
+  static VariableFlags of(const std::shared_ptr<Variable>& var);
+  bool verify(const std::shared_ptr<Variable>& var);
 
   bool requires_grad;
   bool is_volatile;
+  bool was_null;
 };
 
 struct TracingState : public std::enable_shared_from_this<TracingState> {

--- a/torch/csrc/utils/functional.h
+++ b/torch/csrc/utils/functional.h
@@ -5,7 +5,7 @@
 namespace torch {
 
 template<typename F, typename T, typename R = typename std::result_of<F(T)>::type>
-static std::vector<R> fmap(const std::vector<T> & inputs, const F& fn) {
+inline std::vector<R> fmap(const std::vector<T> & inputs, const F& fn) {
   std::vector<R> r;
   r.reserve(inputs.size());
   for(auto & input : inputs)
@@ -13,8 +13,18 @@ static std::vector<R> fmap(const std::vector<T> & inputs, const F& fn) {
   return r;
 }
 
+// C++ forbids taking an address of a constructor, so here's a workaround...
+template<typename R, typename T>
+inline std::vector<R> fmap(const std::vector<T> & inputs) {
+  std::vector<R> r;
+  r.reserve(inputs.size());
+  for(auto & input : inputs)
+    r.push_back(R(input));
+  return r;
+}
+
 template<typename F, typename T>
-static std::vector<T> filter(const std::vector<T> & inputs, const F& fn) {
+inline std::vector<T> filter(const std::vector<T> & inputs, const F& fn) {
   std::vector<T> r;
   r.reserve(inputs.size());
   for(auto & input : inputs) {


### PR DESCRIPTION
These commits fix a few regressions introduced in the previous refactor and improves handling of null Variables in autograd. In a discussion with @colesbury we've decided that removing them requires a few additional changes to autograd and we should just hack this to unblock the JIT.