### PR TITLE
Add simple mode to Eval

### DIFF
--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -89,6 +89,57 @@ auto Eval::getSubgraph(const variable_list& inputs, const variable_list& outputs
   return subgraph;
 }
 
+bool Eval::trySimpleEval(const variable_list& inputs, const variable_list& outputs,
+                         const placeholder_list& inherited_placeholders) {
+  using bitset_type = uint64_t;
+  constexpr std::size_t max_outputs = sizeof(bitset_type) * 8;
+
+  if (inherited_placeholders.size() != 0) return false;
+
+  auto& grad_fn = outputs[0]->grad_fn;
+  if (static_cast<std::size_t>(grad_fn->num_inputs) >= max_outputs) return false;
+  if (static_cast<std::size_t>(grad_fn->num_inputs) != outputs.size()) return false;
+
+  // Check that all outputs have the same grad_fn and cover all its inputs
+  bitset_type output_nrs = 0;
+  bitset_type expected_bitset = ((1 << grad_fn->num_inputs) - 1);
+  for (auto & output : outputs) {
+    if (output->grad_fn != grad_fn) return false;
+    output_nrs |= (1 << output->output_nr);
+  }
+  if (output_nrs != expected_bitset) return false;
+
+  // Check that grad_fn->next_functions matches the inputs exactly
+  auto num_inputs = inputs.size();
+  auto& grad_next_fns = grad_fn->next_functions;
+  if (num_inputs != grad_next_fns.size()) return false;
+  for (std::size_t i = 0; i < num_inputs; ++i) {
+    if (inputs[i]) {
+      const auto& input_grad = inputs[i]->grad_fn ? inputs[i]->grad_fn : inputs[i]->grad_accumulator.lock();
+      if (grad_next_fns[i].first != input_grad || grad_next_fns[i].second != inputs[i]->output_nr) return false;
+    } else {
+      if (grad_next_fns[i].first != nullptr) return false;
+    }
+  }
+
+  // Success! We still need to set up placeholders for next stages and to drop
+  // references to the graph.
+  next_functions = std::move(grad_next_fns);
+  grad_next_fns.reserve(num_inputs);
+  placeholders.reserve(num_inputs);
+  for (std::size_t i = 0; i < num_inputs; ++i) {
+    auto placeholder = std::make_shared<EvalOutput>(next_functions[i]);
+    grad_next_fns.emplace_back(placeholder, 0);
+    placeholders.emplace_back(std::move(placeholder));
+  }
+  is_executable = grad_fn->is_executable;
+  simple_graph = grad_fn;
+  input_sizes = grad_fn->input_sizes;
+  grad_fn->tracing_state->in_eval_subgraph = true;
+  return true;
+}
+
+
 // Here, a _relevant_ output is one that has a grad_fn (is not a leaf and is not
 // volatile) and is not one of the inputs (can happen because of passthrough).
 variable_list Eval::filterRelevantOutputs(const variable_list& inputs, const variable_list& outputs) {
@@ -134,50 +185,55 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
                            const placeholder_list& inherited_placeholders) {
   // _outputs has a prefix deliberately, because it's unlikely that anything else
   // than relevant_outputs will be needed inside this function.
+  // TODO: it would be useful to unpack inputs to their grad_fn/grad_accumulators to avoid
+  // all these ternary operators in functions above
   variable_list relevant_outputs = filterRelevantOutputs(inputs, _outputs);
 
   if (relevant_outputs.size() == 0)
     return false;
 
-  for (auto & output : relevant_outputs)
-    roots.emplace_back(output->grad_fn, output->output_nr);
+  if (!trySimpleEval(inputs, relevant_outputs, inherited_placeholders)) {
+    roots.reserve(relevant_outputs.size());
+    for (auto & output : relevant_outputs)
+      roots.emplace_back(output->grad_fn, output->output_nr);
 
-  auto subgraph = getSubgraph(inputs, relevant_outputs, inherited_placeholders);
+    auto subgraph = getSubgraph(inputs, relevant_outputs, inherited_placeholders);
 
-  // Prepare output placeholder nodes for each end.
-  std::unordered_map<edge_type, std::shared_ptr<EvalOutput>, edge_hasher> ends_to_outputs;
-  for (auto & placeholder : placeholders) {
-    ends_to_outputs[placeholder->next_edge] = placeholder;
-  }
-  for (auto & end : subgraph.boundary.ends) {
-    if (ends_to_outputs.count(end) == 0) {
-      placeholders.emplace_back(std::make_shared<EvalOutput>(end));
-      ends_to_outputs[end] = placeholders.back();
+    // Prepare output placeholder nodes for each end.
+    std::unordered_map<edge_type, std::shared_ptr<EvalOutput>, edge_hasher> ends_to_outputs;
+    for (auto & placeholder : placeholders) {
+      ends_to_outputs[placeholder->next_edge] = placeholder;
     }
+    for (auto & end : subgraph.boundary.ends) {
+      if (ends_to_outputs.count(end) == 0) {
+        placeholders.emplace_back(std::make_shared<EvalOutput>(end));
+        ends_to_outputs[end] = placeholders.back();
+      }
+    }
+
+    // Replace begins with pointers to output nodes.
+    // This detaches the subgraph from the full backward graph.
+    for (auto & begin : subgraph.boundary.begins) {
+      auto & fn = begin.first;
+      auto offset = begin.second;
+      fn->next_functions[offset] = std::make_pair(ends_to_outputs.at(fn->next_functions[offset]), 0);
+    }
+
+    // Replace subgraph with this node.
+    next_functions.insert(next_functions.begin(), subgraph.boundary.ends.begin(), subgraph.boundary.ends.end());
+    is_executable = std::any_of(relevant_outputs.begin(), relevant_outputs.end(),
+                                [](std::shared_ptr<Variable>& var) { return var->requires_grad; });
+    input_sizes = fmap<TensorMeta>(relevant_outputs);
+
+    // Ensure placeholders and inputs are sorted in the same way.
+    edge_order input_order = computeInputOrder(inputs, inherited_placeholders);
+    std::sort(next_functions.begin(), next_functions.end(), [&input_order](const edge_type &a, const edge_type &b) {
+      return input_order.at(a) < input_order.at(b);
+    });
+    std::sort(placeholders.begin(), placeholders.end(), [&input_order](const std::shared_ptr<EvalOutput> &a, const std::shared_ptr<EvalOutput> &b) {
+      return input_order.at(a->next_edge) < input_order.at(b->next_edge);
+    });
   }
-
-  // Replace begins with pointers to output nodes.
-  // This detaches the subgraph from the full backward graph.
-  for (auto & begin : subgraph.boundary.begins) {
-    auto & fn = begin.first;
-    auto offset = begin.second;
-    fn->next_functions[offset] = std::make_pair(ends_to_outputs.at(fn->next_functions[offset]), 0);
-  }
-
-  // Replace subgraph with this node.
-  next_functions.insert(next_functions.begin(), subgraph.boundary.ends.begin(), subgraph.boundary.ends.end());
-  is_executable = std::any_of(relevant_outputs.begin(), relevant_outputs.end(),
-                              [](std::shared_ptr<Variable>& var) { return var->requires_grad; });
-  input_sizes = fmap<TensorMeta>(relevant_outputs);
-
-  // Ensure placeholders and inputs are sorted in the same way.
-  edge_order input_order = computeInputOrder(inputs, inherited_placeholders);
-  std::sort(next_functions.begin(), next_functions.end(), [&input_order](const edge_type &a, const edge_type &b) {
-    return input_order.at(a) < input_order.at(b);
-  });
-  std::sort(placeholders.begin(), placeholders.end(), [&input_order](const std::shared_ptr<EvalOutput> &a, const std::shared_ptr<EvalOutput> &b) {
-    return input_order.at(a->next_edge) < input_order.at(b->next_edge);
-  });
 
   // Rebase outputs.
   for (auto & output : relevant_outputs) {
@@ -189,11 +245,16 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
 }
 
 variable_list Eval::apply(const variable_list& inputs) {
-  std::mutex outputs_mutex;
-  variable_list outputs(placeholders.size());
-  auto& engine = python::PythonEngine::getDefaultEngine();
-  auto exec_data = filterRoots(inputs);
-  engine.execute(exec_data.first, exec_data.second, true, getCallbacks(outputs, outputs_mutex));
+  variable_list outputs;
+  if (simple_graph) {
+    outputs = (*simple_graph)(inputs);
+  } else {
+    std::mutex outputs_mutex;
+    outputs.resize(placeholders.size());
+    auto& engine = python::PythonEngine::getDefaultEngine();
+    auto exec_data = filterRoots(inputs);
+    engine.execute(exec_data.first, exec_data.second, true, getCallbacks(outputs, outputs_mutex));
+  }
 
   auto bw_eval = newEval();
   bw_eval->replaceSubgraph(inputs, outputs, placeholders);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -734,6 +734,13 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
   if (grad_fn->cdata.is_executable) {
     _mark_non_differentiable(grad_fn, t2var);
   }
+  // We need to capture these before _trace_create, because they might
+  // be used by an Eval node that will wrap grad_fn.
+  grad_fn->cdata.input_sizes.reserve(num_outputs);
+  for (int i = 0; i < num_outputs; ++i) {
+    THPVariable* py_var = (THPVariable*)PyTuple_GET_ITEM(outputs.get(), i);
+    grad_fn->cdata.input_sizes.emplace_back(py_var->cdata);
+  }
   // NOTE: _trace_create has to run before _save_variables, because we need
   // to assign traces to outputs before we convert them to SavedVariables.
   // On the other hand, it needs to go after _mark_non_differentiable, because
@@ -748,12 +755,6 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
     grad_fn->to_save = NULL;
     Py_XDECREF(grad_fn->non_differentiable);
     grad_fn->non_differentiable = NULL;
-  }
-
-  grad_fn->cdata.input_sizes.reserve(num_outputs);
-  for (int i = 0; i < num_outputs; ++i) {
-    THPVariable* py_var = (THPVariable*)PyTuple_GET_ITEM(outputs.get(), i);
-    grad_fn->cdata.input_sizes.emplace_back(py_var->cdata);
   }
 
   // Unpack the output, unless .forward() returned a tuple


### PR DESCRIPTION
For first backward, the Eval wraps only a single function, and we can save a lot of allocations and cycles by skipping initialization of all data structures we need to perform the graphs search for a "general case".

This is one approach to do it, but now I think it might be even simpler to just provide another `replaceSubgraph` overload, that would do no graph traversal and would be used only by forward functions (which is a bit awkward, because we don't always know what C++ functions are forward/backward; I'm not sure if adding yet another virtual method is a good idea).

Word language model run times:

|                   | forward | backward |
|-------------------|---------|----------|
| No JIT            | 40ms    | 72ms     |
| JIT               | 49ms    | 105ms    |
| JIT + simple Eval | 37ms    | 75ms     |