### PR TITLE
Add JIT_EXPECT

### DIFF
--- a/torch/csrc/autograd/functions/onnx/convolution.cpp
+++ b/torch/csrc/autograd/functions/onnx/convolution.cpp
@@ -4,10 +4,10 @@ namespace torch { namespace autograd {
 
 template<typename T>
 static T all_equal(at::ArrayRef<T> ts, const char * name) {
-  JIT_ASSERT(ts.size() > 0);
+  JIT_EXPECT(ts.size() > 0);
   auto v = ts[0];
   for(auto t : ts) {
-    JIT_ASSERTM(v == t, "all elements of %s must be the same for transposed", name);
+    JIT_EXPECTM(v == t, "all elements of %s must be the same for transposed", name);
   }
   return v;
 }
@@ -66,7 +66,7 @@ jit::node_list ConvForward::symbolic(SymbolicContext* ctx, jit::node_list inputs
 
   // Not in ONNX?
   for (int p : output_padding) {
-    JIT_ASSERT(p == 0);
+    JIT_EXPECT(p == 0);
   }
 
   // ignore benchmark/cudnn_enabled

--- a/torch/csrc/autograd/functions/onnx/convolution.cpp
+++ b/torch/csrc/autograd/functions/onnx/convolution.cpp
@@ -2,16 +2,6 @@
 
 namespace torch { namespace autograd {
 
-template<typename T>
-static T all_equal(at::ArrayRef<T> ts, const char * name) {
-  JIT_EXPECT(ts.size() > 0);
-  auto v = ts[0];
-  for(auto t : ts) {
-    JIT_EXPECTM(v == t, "all elements of %s must be the same for transposed", name);
-  }
-  return v;
-}
-
 // Note [Caffe2ConvTranspose]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ConvTranspose in Caffe2 is a bit silly: bias is mandatory.  But ONNX
@@ -66,7 +56,7 @@ jit::node_list ConvForward::symbolic(SymbolicContext* ctx, jit::node_list inputs
 
   // Not in ONNX?
   for (int p : output_padding) {
-    JIT_EXPECT(p == 0);
+    JIT_EXPECTM(p == 0, "output padding is not supported.");
   }
 
   // ignore benchmark/cudnn_enabled

--- a/torch/csrc/jit/assert.h
+++ b/torch/csrc/jit/assert.h
@@ -30,6 +30,7 @@ void barf(const char *fmt, ...);
 
 #define JIT_ASSERTM(...) _JIT_ASSERTM(__VA_ARGS__, ' ')
 
+// Note: msg must be a string literal
 #define _JIT_ASSERTM(cond, msg, ...) \
   if (__builtin_expect(!(cond), 0)) { \
     ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__); \
@@ -37,6 +38,7 @@ void barf(const char *fmt, ...);
 
 #define JIT_EXPECTM(...) _JIT_EXPECTM(__VA_ARGS__, ' ')
 
+// Note: msg must be a string literal
 #define _JIT_EXPECTM(cond, msg, ...) \
   if (__builtin_expect(!(cond), 0)) { \
     ::torch::jit::barf("%s:%u: %s: " msg, __FILE__, __LINE__, __func__, __VA_ARGS__); \

--- a/torch/csrc/jit/assert.h
+++ b/torch/csrc/jit/assert.h
@@ -28,6 +28,9 @@ void barf(const char *fmt, ...);
     ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed.", __FILE__, __LINE__, __func__, #cond); \
   }
 
+// The trailing ' ' argument is a hack to deal with the extra comma when ... is empty.
+// Another way to solve this is ##__VA_ARGS__ in _JIT_ASSERTM, but this is a non-portable
+// extension we shouldn't use.
 #define JIT_ASSERTM(...) _JIT_ASSERTM(__VA_ARGS__, ' ')
 
 // Note: msg must be a string literal

--- a/torch/csrc/jit/assert.h
+++ b/torch/csrc/jit/assert.h
@@ -28,17 +28,16 @@ void barf(const char *fmt, ...);
     ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed.", __FILE__, __LINE__, __func__, #cond); \
   }
 
-//note: msg must be a string literal
-//node: In, ##__VA_ARGS '##' supresses the comma if __VA_ARGS__ is empty
-#define JIT_ASSERTM(cond, msg, ...) \
+#define JIT_ASSERTM(...) _JIT_ASSERTM(__VA_ARGS__, ' ')
+
+#define _JIT_ASSERTM(cond, msg, ...) \
   if (__builtin_expect(!(cond), 0)) { \
-    ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed: " msg , __FILE__, __LINE__, __func__, #cond, ##__VA_ARGS__); \
+    ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__); \
   }
 
-//note: msg must be a string literal
-//node: In, ##__VA_ARGS '##' supresses the comma if __VA_ARGS__ is empty
-#define JIT_EXPECTM(cond, msg, ...) \
+#define JIT_EXPECTM(...) _JIT_EXPECTM(__VA_ARGS__, ' ')
+
+#define _JIT_EXPECTM(cond, msg, ...) \
   if (__builtin_expect(!(cond), 0)) { \
-    ::torch::jit::barf("%s:%u: %s: Invalid user input failed the check `%s`: " msg , __FILE__, __LINE__, __func__, \
-                       #cond, ##__VA_ARGS__); \
+    ::torch::jit::barf("%s:%u: %s: " msg, __FILE__, __LINE__, __func__, __VA_ARGS__); \
   }

--- a/torch/csrc/jit/assert.h
+++ b/torch/csrc/jit/assert.h
@@ -34,3 +34,16 @@ void barf(const char *fmt, ...);
   if (__builtin_expect(!(cond), 0)) { \
     ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed: " msg , __FILE__, __LINE__, __func__, #cond,##__VA_ARGS__); \
   }
+
+#define JIT_EXPECT(cond) \
+  if (__builtin_expect(!(cond), 0)) { \
+    ::torch::jit::barf("%s:%u: %s: Invalid user input failed the check `%s`.", __FILE__, __LINE__, __func__, #cond); \
+  }
+
+//note: msg must be a string literal
+//node: In, ##__VA_ARGS '##' supresses the comma if __VA_ARGS__ is empty
+#define JIT_EXPECTM(cond, msg, ...) \
+  if (__builtin_expect(!(cond), 0)) { \
+    ::torch::jit::barf("%s:%u: %s: Invalid user input failed the check `%s`: " msg , __FILE__, __LINE__, __func__, \
+                       #cond,##__VA_ARGS__); \
+  }

--- a/torch/csrc/jit/assert.h
+++ b/torch/csrc/jit/assert.h
@@ -32,12 +32,7 @@ void barf(const char *fmt, ...);
 //node: In, ##__VA_ARGS '##' supresses the comma if __VA_ARGS__ is empty
 #define JIT_ASSERTM(cond, msg, ...) \
   if (__builtin_expect(!(cond), 0)) { \
-    ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed: " msg , __FILE__, __LINE__, __func__, #cond,##__VA_ARGS__); \
-  }
-
-#define JIT_EXPECT(cond) \
-  if (__builtin_expect(!(cond), 0)) { \
-    ::torch::jit::barf("%s:%u: %s: Invalid user input failed the check `%s`.", __FILE__, __LINE__, __func__, #cond); \
+    ::torch::jit::barf("%s:%u: %s: Assertion `%s` failed: " msg , __FILE__, __LINE__, __func__, #cond, ##__VA_ARGS__); \
   }
 
 //note: msg must be a string literal
@@ -45,5 +40,5 @@ void barf(const char *fmt, ...);
 #define JIT_EXPECTM(cond, msg, ...) \
   if (__builtin_expect(!(cond), 0)) { \
     ::torch::jit::barf("%s:%u: %s: Invalid user input failed the check `%s`: " msg , __FILE__, __LINE__, __func__, \
-                       #cond,##__VA_ARGS__); \
+                       #cond, ##__VA_ARGS__); \
   }

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -117,10 +117,10 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     for (auto arg_type : op->cconv) {
       py::object obj;
       if (arg_type == 's') {
-        JIT_EXPECTM(scalar_it != op->scalar_args.end(), "expected too many scalar args");
+        JIT_ASSERTM(scalar_it != op->scalar_args.end(), "expected too many scalar args");
         obj = py::reinterpret_borrow<py::object>(py::handle((scalar_it++)->get()));
       } else if (arg_type == 't') {
-        JIT_EXPECTM(node_it != op->inputs().end(), "expected too many inputs");
+        JIT_ASSERTM(node_it != op->inputs().end(), "expected too many inputs");
         obj = py::cast(envFn(*node_it++));
       } else {
         throw std::runtime_error("unexpected calling convention");
@@ -154,7 +154,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     }
     IR_IF(node, Select)
       // Selects are translated by multi-return nodes.
-      JIT_EXPECT(env.count(value) > 0);
+      JIT_ASSERT(env.count(value) > 0);
     IR_ELSEIFM(CppOp)
       if (auto fn = std::dynamic_pointer_cast<autograd::HasSymbolic>(value->fn)) {
         auto outputs = fn->symbolic(&ctx, fmap(node->inputs(), envFn));

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -117,10 +117,10 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     for (auto arg_type : op->cconv) {
       py::object obj;
       if (arg_type == 's') {
-        JIT_ASSERTM(scalar_it != op->scalar_args.end(), "expected too many scalar args");
+        JIT_EXPECTM(scalar_it != op->scalar_args.end(), "expected too many scalar args");
         obj = py::reinterpret_borrow<py::object>(py::handle((scalar_it++)->get()));
       } else if (arg_type == 't') {
-        JIT_ASSERTM(node_it != op->inputs().end(), "expected too many inputs");
+        JIT_EXPECTM(node_it != op->inputs().end(), "expected too many inputs");
         obj = py::cast(envFn(*node_it++));
       } else {
         throw std::runtime_error("unexpected calling convention");
@@ -154,7 +154,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     }
     IR_IF(node, Select)
       // Selects are translated by multi-return nodes.
-      JIT_ASSERT(env.count(value) > 0);
+      JIT_EXPECT(env.count(value) > 0);
     IR_ELSEIFM(CppOp)
       if (auto fn = std::dynamic_pointer_cast<autograd::HasSymbolic>(value->fn)) {
         auto outputs = fn->symbolic(&ctx, fmap(node->inputs(), envFn));


### PR DESCRIPTION
#120 

Introduce JIT_EXPECT. The implementation is almost the same as JIT_ASSERT.

Right now, if the check/assertion is directly on the user input, we call JIT_EXPECT.
Otherwise, we keep using JIT_ASSERT.