### PR TITLE
Add pybind11 type_caster to header file torch/csrc/utils/pybind.h

### DIFF
--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -1,4 +1,3 @@
-#include "torch/csrc/utils/pybind.h"
 #include "batch_normalization.h"
 #include "convolution.h"
 #include "accumulate_grad.h"
@@ -6,31 +5,10 @@
 #include "tensor.h"
 #include "special.h"
 #include "jit_closure.h"
-#include "torch/csrc/THP.h"
-#include "torch/csrc/autograd/python_cpp_function.h"
+#include "torch/csrc/autograd/functions/pybind.h"
 #include "torch/csrc/jit/python_tracer.h"
+#include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/utils/tuple_parser.h"
-#include "torch/csrc/DynamicTypes.h"
-
-namespace pybind11 { namespace detail {
-
-// handle Python <-> torch::autograd::Function conversions
-template <> struct type_caster<std::shared_ptr<torch::autograd::Function>> {
-public:
-  PYBIND11_TYPE_CASTER(std::shared_ptr<torch::autograd::Function>, _("std::shared_ptr<torch::autograd::Function>"));
-
-  bool load(handle src, bool) {
-    if (!THPFunction_Check(src.ptr())) return false;
-    value = THPFunction_asFunction((THPFunction*)src.ptr());
-    return true;
-  }
-  static handle cast(std::shared_ptr<torch::autograd::Function> src, return_value_policy /* policy */, handle /* parent */) {
-    auto fn = functionToPyObject(src);
-    return handle(fn);
-  }
-};
-
-}} // namespace pybind11::detail
 
 using namespace torch::autograd;
 using torch::TupleParser;

--- a/torch/csrc/autograd/functions/pybind.h
+++ b/torch/csrc/autograd/functions/pybind.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Python.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "torch/csrc/autograd/python_cpp_function.h"
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/THP.h"
+
+namespace py = pybind11;
+
+namespace pybind11 { namespace detail {
+
+// handle Python <-> torch::autograd::Function conversions
+template <> struct type_caster<std::shared_ptr<torch::autograd::Function>> {
+public:
+  PYBIND11_TYPE_CASTER(std::shared_ptr<torch::autograd::Function>, _("std::shared_ptr<torch::autograd::Function>"));
+
+  bool load(handle src, bool) {
+    if (!THPFunction_Check(src.ptr())) return false;
+    value = THPFunction_asFunction((THPFunction*)src.ptr());
+    return true;
+  }
+  static handle cast(std::shared_ptr<torch::autograd::Function> src, return_value_policy /* policy */, handle /* parent */) {
+    auto fn = functionToPyObject(src);
+    return handle(fn);
+  }
+};
+
+
+}} // namespace pybind11::detail
+

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <Python.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/THP.h"
+
+namespace py = pybind11;
+
+namespace pybind11 { namespace detail {
+
+template<> struct type_caster<torch::jit::tracer::TraceInput> {
+public:
+  PYBIND11_TYPE_CASTER(torch::jit::tracer::TraceInput, _("torch::jit::tracer::TraceInput"));
+  bool load(handle src, bool) {
+    PyObject *source = src.ptr();
+    if (THPVariable_Check(source)) {
+      value = torch::jit::tracer::TraceInput(((THPVariable*)source)->cdata);
+      return true;
+    } else if (THPModule_isTensor(source)) {
+      value = torch::jit::tracer::TraceInput(torch::createTensor(source));
+      return true;
+    } else {
+      return false;
+    }
+  }
+  static handle cast(torch::jit::tracer::TraceInput src, return_value_policy /* policy */, handle /* parent */) {
+    if (src.variable.defined()) {
+      return handle(THPVariable_Wrap(src.variable));
+    } else {
+      return handle(torch::createPyObject(src.buffer));
+    }
+  }
+};
+
+template<> struct type_caster<torch::autograd::Variable> {
+public:
+  PYBIND11_TYPE_CASTER(torch::autograd::Variable, _("torch::autograd::Variable"));
+  bool load(handle src, bool) {
+    PyObject *source = src.ptr();
+    if (THPVariable_Check(source)) {
+      value = ((THPVariable*)source)->cdata;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  static handle cast(torch::autograd::Variable src, return_value_policy /* policy */, handle /* parent */) {
+    return handle(THPVariable_Wrap(src));
+  }
+};
+
+template <> struct type_caster<torch::jit::Symbol> {
+public:
+  PYBIND11_TYPE_CASTER(torch::jit::Symbol, _("Symbol"));
+
+  bool load(handle src, bool) {
+    try {
+      value = torch::jit::stringToSymbol(py::cast<std::string>(src));
+    } catch (std::exception& e) {
+      return false;
+    }
+    return true;
+  }
+
+  static handle cast(torch::jit::Symbol src, return_value_policy /* policy */, handle /* parent */) {
+    return py::cast(std::string(torch::jit::symbolToString(src)), return_value_policy::copy).release();
+  }
+};
+
+template <> struct type_caster<torch::jit::AttributeKind> {
+public:
+  PYBIND11_TYPE_CASTER(torch::jit::AttributeKind, _("AttributeKind"));
+
+  bool load(handle src, bool) {
+    return false;
+  }
+
+  static handle cast(torch::jit::AttributeKind src, return_value_policy /* policy */, handle /* parent */) {
+    return py::cast(std::string(torch::jit::toString(src)), return_value_policy::copy).release();
+  }
+};
+
+}} // namespace pybind11::detail
+

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -1,43 +1,9 @@
-#include "torch/csrc/utils/pybind.h"
 #include <iostream>
 #include <sstream>
 #include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/jit/python_tracer.h"
-
-namespace pybind11 { namespace detail {
-
-template <> struct type_caster<torch::jit::Symbol> {
-public:
-  PYBIND11_TYPE_CASTER(torch::jit::Symbol, _("Symbol"));
-
-  bool load(handle src, bool) {
-    try {
-      value = torch::jit::stringToSymbol(py::cast<std::string>(src));
-    } catch (std::exception& e) {
-      return false;
-    }
-    return true;
-  }
-
-  static handle cast(torch::jit::Symbol src, return_value_policy /* policy */, handle /* parent */) {
-    return py::cast(std::string(torch::jit::symbolToString(src)), return_value_policy::copy).release();
-  }
-};
-
-template <> struct type_caster<torch::jit::AttributeKind> {
-public:
-  PYBIND11_TYPE_CASTER(torch::jit::AttributeKind, _("AttributeKind"));
-
-  bool load(handle src, bool) {
-    return false;
-  }
-
-  static handle cast(torch::jit::AttributeKind src, return_value_policy /* policy */, handle /* parent */) {
-    return py::cast(std::string(torch::jit::toString(src)), return_value_policy::copy).release();
-  }
-};
-
-}} // namespace pybind11::detail
+#include "torch/csrc/utils/pybind.h"
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -1,67 +1,17 @@
 #include <Python.h>
 
-#include <pybind11/pybind11.h>
-// DO NOT REMOVE, this enables std containers to be recognized
-// with pybind11, removing the include disables the support
-#include <pybind11/stl.h>
-namespace py = pybind11;
-
 #include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/jit/assert.h"
 #include "torch/csrc/jit/export.h"
+#include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/utils/python_strings.h"
-#include "torch/csrc/THP.h"
-#include "torch/csrc/DynamicTypes.h"
 
 #include <sstream>
 
 using namespace torch::autograd;
 using namespace torch::jit;
 using namespace torch::jit::tracer;
-
-namespace pybind11 { namespace detail {
-  template<> struct type_caster<TraceInput> {
-  public:
-    PYBIND11_TYPE_CASTER(TraceInput, _("torch::jit::tracer::TraceInput"));
-    bool load(handle src, bool) {
-      PyObject *source = src.ptr();
-      if (THPVariable_Check(source)) {
-        value = TraceInput(((THPVariable*)source)->cdata);
-        return true;
-      } else if (THPModule_isTensor(source)) {
-        value = TraceInput(torch::createTensor(source));
-        return true;
-      } else {
-        return false;
-      }
-    }
-    static handle cast(TraceInput src, return_value_policy /* policy */, handle /* parent */) {
-      if (src.variable.defined()) {
-        return handle(THPVariable_Wrap(src.variable));
-      } else {
-        return handle(torch::createPyObject(src.buffer));
-      }
-    }
-  };
-
-  template<> struct type_caster<Variable> {
-  public:
-    PYBIND11_TYPE_CASTER(Variable, _("torch::autograd::Variable"));
-    bool load(handle src, bool) {
-      PyObject *source = src.ptr();
-      if (THPVariable_Check(source)) {
-        value = ((THPVariable*)source)->cdata;
-        return true;
-      } else {
-        return false;
-      }
-    }
-    static handle cast(Variable src, return_value_policy /* policy */, handle /* parent */) {
-      return handle(THPVariable_Wrap(src));
-    }
-  };
-}}
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+
 #include "torch/csrc/DynamicTypes.h"
 
 namespace py = pybind11;


### PR DESCRIPTION
#154 We can put the type_caster into header file torch/csrc/utils/pybind.h.