### PR TITLE
Reproduction for TensorMetas problem

### DIFF
--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -63,14 +63,12 @@ variable_list Function::tracedApply(variable_list inputs) {
   int num_outputs = outputs.size();
   for (int i = 0; i < num_outputs; ++i) {
     auto& output = outputs[i];
-    if (!output.defined()) {
-      auto & edge = next_functions[i];
-      auto & meta = edge.first->input_sizes.at(edge.second);
-      output = meta.recreate();
-    }
     Node* sel = graph->appendNode(graph->createSelect(this_node, i));
-    sel->inferTypeFrom(output.data());
-    tracer::setValueTrace(state, output, sel);
+    // TODO: This causes a bug in word_language_model
+    if (output.defined()) {
+      sel->inferTypeFrom(output.data());
+      tracer::setValueTrace(state, output, sel);
+    }
   }
 
   if (!passes_state_transparently()) {

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -32,6 +32,7 @@ using saved_variable_list = std::vector<SavedVariable>;
 struct TensorMeta {
   TensorMeta(const Variable& var) {
     if (var.defined()) {
+      defined = true;
       sizes = var.data().sizes();
       device = var.data().type().isCuda() ? var.data().get_device() : -1;
       type = &var.data().type();
@@ -39,16 +40,16 @@ struct TensorMeta {
   }
 
   Variable recreate() {
-    AutoGPU gpu_guard(device);
     if (!defined)
       throw std::logic_error("Recreating undefined TensorMeta");
+    AutoGPU gpu_guard(device);
     return Variable(new VariableImpl(type->zeros(sizes), false, false), false);
   }
 
   std::vector<int64_t> sizes;
   int device;
   at::Type* type;
-  bool defined;
+  bool defined = false;
 };
 using tensor_meta_list = std::vector<TensorMeta>;
 

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -120,8 +120,8 @@ struct EmitNull : public Function {
 struct LambdaFunction : public Function {
   LambdaFunction(int num_inputs, std::function<variable_list(const variable_list&)> fn)
     : fn(fn) {
-    is_executable = true;
-    num_inputs = num_inputs;
+    this->is_executable = true;
+    this->num_inputs = num_inputs;
   }
 
   virtual variable_list apply(const variable_list& inputs) {
@@ -272,7 +272,7 @@ struct FusionGroupFunction : public Function {
     std::vector<at::Tensor> outputs;
     outputs.reserve(function->outputDescriptors().size());
     for(auto & od : function->outputDescriptors()) {
-      outputs.push_back(at::CUDA(od.scalar_type).tensor(data.back().sizes()));
+      outputs.push_back(at::CUDA(od.scalar_type).tensor());
     }
     function->launch(data, outputs);
     return wrap_outputs(inputs, std::move(outputs), [](FunctionFlags f) {

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -562,7 +562,7 @@ struct StageClosure {
     if (node->hasMultipleOutputs()) {
       // Each use is a single Select node corresponding to an output
       for (auto& use : node->uses()) {
-        if (use.user->type()->kind() == TypeKind::HandleType) continue;
+        if (use.user->hasType() && use.user->type()->kind() == TypeKind::HandleType) continue;
         auto& select_uses = use.user->uses();
         output_uses_refs.emplace_back(select_uses);
       }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -31,7 +31,6 @@ _(AddConstant) \
 _(Transpose) \
 _(Reshape) \
 _(split) \
-_(Dim) \
 _(Offset) \
 _(value) \
 _(Subgraph) \

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -224,7 +224,11 @@ std::ostream& printNode(std::ostream & out, Node * n, std::vector<Node*> * group
     for (auto& scalar : value->scalar_args) {
       if (i++ > 0)
         out << ", ";
-      out << scalar;
+      {
+        // TODO: make this less error prone
+        AutoGIL gil;
+        out << scalar;
+      }
     }
     out << ")";
   IR_ELSEIF(FusionGroup)

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -11,7 +11,8 @@ std::unordered_set<NodeKind> simple_mappable = {
   kMul,
   kAdd,
   kNeg,
-  kAddConstant
+  kAddConstant,
+  kConcat,
 };
 
 bool isSimpleMap(Node *node) {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -173,7 +173,34 @@ static void fusionTests() {
   testOne(0,1,1,2);
   testOne(1,2,0,2);
 
+
+
+  auto testConcat = [&](int dim) {
+    Graph graph;
+    Node * i0 = graph.addInput();
+    Node * i1 = graph.addInput();
+    auto o0 = appendNewNode(kMul,graph,{i0, i1});
+    graph.registerOutput(o0);
+    graph.registerOutput(appendNewNode(kConcat, graph, {i0,o0})->i_(kaxis, dim));
+    auto a = at::CUDA(at::kFloat).rand({3,4,5});
+    auto b = at::CUDA(at::kFloat).rand({4,3,5}).transpose(0,1);
+    auto o = at::CUDA(at::kFloat).zeros({3,4,5});
+
+    auto o_r = a*b;
+    auto o2_r = at::cat({a, o_r}, dim);
+    auto o2 = at::CUDA(at::kFloat).zeros(o2_r.sizes());
+    comp.debugLaunchGraph(graph, {a,b}, {o, o2});
+
+    float max_diff = (o_r - o).abs().max().toDouble();
+    JIT_ASSERT(max_diff == 0);
+    float max_diff2 = (o2_r - o2).abs().max().toDouble();
+    JIT_ASSERT(max_diff2 == 0);
+  };
+  testConcat(0);
+  testConcat(1);
+  testConcat(2);
 }
+
 #else //WITH_CUDA
 void fusionTests() {}
 #endif

--- a/torch/jit.py
+++ b/torch/jit.py
@@ -88,11 +88,21 @@ def _verify(flat_trace_out, flat_real_out):
             raise RuntimeError("JIT and real computation mismatch")
 
 
+_dump_traces = os.environ.get('PYTORCH_JIT_DUMP', False)
+
+
+def _dump_trace(trace_name, name, suffix, complete_trace):
+    if not _dump_traces:
+        return
+    filename = "{}_{}_{}".format(trace_name, name, suffix)
+    with open(filename + ".ir", "w") as f:
+        f.write(str(complete_trace))
+    complete_trace.graph().write_vis(filename + ".html")
+
 # holds run() to run the function and self.inputs which
 # are all the variable inputs
 class Traceable(object):
     _next_trace_id = 0
-    _dump_traces = os.environ.get('PYTORCH_JIT_DUMP', False)
     VOLATILE = object()
 
     # Traceable holds multiple traces and switches between them based on
@@ -110,13 +120,9 @@ class Traceable(object):
 
         def _run_pass(self, p):
             name = p.__name__.replace('_jit_pass_', '')
-            if Traceable._dump_traces:
-                with open("{}_{}_input.ir".format(self.trace_name, name), "w") as f:
-                    f.write(str(self.complete_trace))
+            _dump_trace(self.trace_name, name, 'input', self.complete_trace)
             p(self.complete_trace)
-            if Traceable._dump_traces:
-                with open("{}_{}_output.ir".format(self.trace_name, name), "w") as f:
-                    f.write(str(self.complete_trace))
+            _dump_trace(self.trace_name, name, 'output', self.complete_trace)
             # TODO: Make linting optional
             torch._C._jit_pass_lint(self.complete_trace)
 

--- a/torch/jit.py
+++ b/torch/jit.py
@@ -208,6 +208,8 @@ class Traceable(object):
         out = self._run(*args)
         torch._C._tracer_exit(flatten(out))
 
+        _dump_trace(self.trace_name, 'trace', 'initial', trace)
+
         return trace, out
 
     def has_trace_for(self, *args):

--- a/torch/onnx.py
+++ b/torch/onnx.py
@@ -106,9 +106,7 @@ _vis_template = string.Template("""
 
   <style type="text/css">
     #mynetwork {
-      width: 1920px;
-      height: 1080px;
-      border: 1px solid lightgray;
+      height: 100vh;
     }
   </style>
 </head>
@@ -159,21 +157,27 @@ def _write_vis(self, filename):
         if (i, n) in existing:
             return
         existing.add((i, n))
-        edges.append({
+        e = {
             'from': n.unique(),
             'to': i.unique(),
             'arrows': 'from',
-        })
+        }
+        if i.stage() != n.stage():
+            e['color'] = 'green'
+        edges.append(e)
 
     counts = {}
+    offset = 0
     for n in self.nodes():
-        if len(n.uses()) == 0 or n.kind() == 'Select':
+        if len(n.uses()) == 0 or n.kind() == 'Select' or n.kind() == 'Undefined':
             continue
-        ident = counts.get(n.kind(),0)
+        ident = counts.get(n.kind(), 0)
         counts[n.kind()] = ident + 1
         d = {
             'id': n.unique(),
             'label': '{}_{}'.format(n.kind(), ident),
+            'y': offset,
+            'fixed': {'y': True},
         }
         if n in self.outputs():
             d['shape'] = 'triangle'
@@ -182,6 +186,7 @@ def _write_vis(self, filename):
             add_edge(i, n)
 
         nodes.append(d)
+        offset += 30
 
     result = _vis_template.substitute(nodes=json.dumps(nodes),
                                       edges=json.dumps(edges),


### PR DESCRIPTION
I took Zach's PR at https://github.com/ezyang/pytorch/pull/224 and reproduced his problem on word_language_model. While debugging, I noted that TensorMeta was not initialized correctly, and I fixed this, though this did not fix word language model: "TensorMeta uninitialized member bugfix." Then, I added two minimized test cases from WLM which induce the TensorMeta failure: the problem is that backwards returns None as a grad_input for an input that was a leaf variable. Returning null means we attempt to reconstitute a TensorMeta, but because the input is a leaf variable, input_sizes is never set on its next_function.

I experimented with a fix that deletes TensorMetas altogether: "DO NOT MERGE. Proof of concept alternative to TensorMetas." but this still fails on WLM. The minimal repro is "Minimized, failing test case".

Finally, "Take out GIL before printing Python scalars." and "Dump the forward only trace once we have it." are two minor fixes which make debugging easier (solving an observed segfault when dumping graphs in C++ code, and the fact that backwards failure meant `PYTORCH_JIT_DUMP=1` did not dump any environment variables).
