### PR TITLE
Prune null edges in Eval nodes

### DIFF
--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -63,14 +63,11 @@ variable_list Function::tracedApply(variable_list inputs) {
   int num_outputs = outputs.size();
   for (int i = 0; i < num_outputs; ++i) {
     auto& output = outputs[i];
-    if (!output.defined()) {
-      auto & edge = next_functions[i];
-      auto & meta = edge.first->input_sizes.at(edge.second);
-      output = meta.recreate();
-    }
     Node* sel = graph->appendNode(graph->createSelect(this_node, i));
-    sel->inferTypeFrom(output.data());
-    tracer::setValueTrace(state, output, sel);
+    if (output.defined()) {
+      sel->inferTypeFrom(output.data());
+      tracer::setValueTrace(state, output, sel);
+    }
   }
 
   if (!passes_state_transparently()) {

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -14,7 +14,6 @@ AccumulateGrad::AccumulateGrad(Variable variable_)
    : variable(std::move(variable_)) {
   num_inputs = 1;
   is_executable = 1;
-  input_sizes.emplace_back(variable_);
 }
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -764,6 +764,7 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
   auto& engine = python::PythonEngine::getDefaultEngine();
   engine.execute(stage_closure.roots, input_leaves, true, pre_callbacks, post_callbacks);
 
+  // See Note [Null-edge pruning]
   auto relevant_inputs = filter(inputs, [](const Variable& var) { return var.defined() && var.requires_grad(); });
   auto result = wrap_outputs(relevant_inputs, std::move(outputs), [this](FunctionFlags f) -> std::shared_ptr<Function> {
     if (this->stage == this->desc->stages.size() - 1) {

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -764,7 +764,8 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
   auto& engine = python::PythonEngine::getDefaultEngine();
   engine.execute(stage_closure.roots, input_leaves, true, pre_callbacks, post_callbacks);
 
-  auto result = wrap_outputs(inputs, std::move(outputs), [this](FunctionFlags f) -> std::shared_ptr<Function> {
+  auto relevant_inputs = filter(inputs, [](const Variable& var) { return var.defined() && var.requires_grad(); });
+  auto result = wrap_outputs(relevant_inputs, std::move(outputs), [this](FunctionFlags f) -> std::shared_ptr<Function> {
     if (this->stage == this->desc->stages.size() - 1) {
       std::string msg = "JIT closure compiled only for ";
       msg += std::to_string(this->stage);

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -143,7 +143,6 @@ bool Eval::trySimpleEval(const variable_list& inputs, const variable_list& outpu
   }
   is_executable = grad_fn->is_executable;
   simple_graph = grad_fn;
-  input_sizes = grad_fn->input_sizes;
   grad_fn->tracing_state->in_eval_subgraph = true;
   return true;
 }
@@ -226,7 +225,6 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
     next_functions.insert(next_functions.begin(), subgraph.boundary.ends.begin(), subgraph.boundary.ends.end());
     is_executable = std::any_of(relevant_outputs.begin(), relevant_outputs.end(),
                                 [](const Variable& var) { return var.requires_grad(); });
-    input_sizes = fmap<TensorMeta>(relevant_outputs);
 
     // Ensure placeholders and inputs are sorted in the same way.
     edge_order input_order = computeInputOrder(inputs, inherited_placeholders);

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -20,11 +20,6 @@ struct EvalOutput : Function {
     // confuse some of the functions causing them to do unnecessary work.
     // TODO: it should be possible to improve this once we get rid of NULL Variables
     is_executable = true;
-    if (next_edge.first) {
-      input_sizes.emplace_back(next_edge.first->input_sizes.at(next_edge.second));
-    } else {
-      input_sizes.emplace_back(Variable());
-    }
   }
 
   virtual variable_list apply(const variable_list& inputs) override {

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -31,7 +31,6 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
         result.emplace_back();
       }
     }
-    grad_fn->input_sizes = fmap<TensorMeta>(result);
   }
   return result;
 }

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -736,13 +736,6 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
   if (grad_fn->cdata.is_executable) {
     _mark_non_differentiable(grad_fn, t2var);
   }
-  // We need to capture these before _trace_create, because they might
-  // be used by an Eval node that will wrap grad_fn.
-  grad_fn->cdata.input_sizes.reserve(num_outputs);
-  for (int i = 0; i < num_outputs; ++i) {
-    THPVariable* py_var = (THPVariable*)PyTuple_GET_ITEM(outputs.get(), i);
-    grad_fn->cdata.input_sizes.emplace_back(py_var->cdata);
-  }
   // NOTE: _trace_create has to run before _save_variables, because we need
   // to assign traces to outputs before we convert them to SavedVariables.
   // On the other hand, it needs to go after _mark_non_differentiable, because


### PR DESCRIPTION
Recent autograd refactor has destabilized the tracer, because it has to handle NULL edges in the graph now (it reverted some of my previous changes). This should fix it (`word_language_model` seems to run just fine)